### PR TITLE
feat: Compose Examples Explorer with Dockerfile enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Visual builder with full spec compliance:
 - **Graceful Error Handling** - Detailed error messages with context and suggestions
 - **Zero Setup Required** - Works entirely in the browser, no backend needed
 
+### 🧭 **Examples Gallery — Powered by [awesome-compose](https://github.com/docker/awesome-compose)**
+
+Browse and visualize production-ready Docker Compose configurations directly from Docker's official [awesome-compose](https://github.com/docker/awesome-compose) repository — 40+ real-world stacks available on-demand:
+
+- **Full awesome-compose Access** - Browse the entire repository without leaving Compoviz. Pick any stack (Flask, Django, React, WordPress, ELK, and dozens more) and visualize it instantly
+- **On-Demand Fetching** - Compose files are loaded from GitHub when you need them — nothing bundled, always up to date
+- **Dockerfile Enrichment** - Services with `build:` directives automatically resolve their base images from Dockerfiles, so you see what's actually running (e.g., `python:3.11-slim` instead of just "build")
+- **Zero Config** - No cloning, no setup. Click an example, see the architecture
+- **Category Filtering & Search** - Find what you need fast across web, fullstack, monitoring, and more
+
 ---
 
 ## 🆕 What's New

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compoviz",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compoviz",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
         "@hpcc-js/wasm-graphviz": "^1.18.0",
         "@vercel/analytics": "^1.6.1",
@@ -31,6 +31,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "fast-check": "^4.7.0",
         "globals": "^16.5.0",
         "happy-dom": "^20.1.0",
         "tailwindcss": "^4.1.18",
@@ -3476,6 +3477,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5287,6 +5311,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "fast-check": "^4.7.0",
     "globals": "^16.5.0",
     "happy-dom": "^20.1.0",
     "tailwindcss": "^4.1.18",

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import {
-    Upload, PenTool, Eye, GitCompare, Zap, ArrowRight, Folder
+    Upload, PenTool, Eye, GitCompare, Zap, ArrowRight, Folder, Compass
 } from 'lucide-react';
+import ExamplesGallery from './ExamplesGallery';
 
 /**
  * EmptyState — The first thing users see when no compose file is loaded.
@@ -10,8 +11,9 @@ import {
  * 2. Import your own file
  * 3. Feature highlights to build confidence
  */
-export default function EmptyState({ onImport, onTryDemo, isDragging, setIsDragging, onDrop }) {
+export default function EmptyState({ onImport, onTryDemo, onLoadExample, isDragging, setIsDragging, onDrop }) {
     const [hoveredFeature, setHoveredFeature] = useState(null);
+    const [showGallery, setShowGallery] = useState(false);
 
     const features = [
         {
@@ -84,6 +86,14 @@ export default function EmptyState({ onImport, onTryDemo, isDragging, setIsDragg
                             Import Folder
                             <input type="file" accept=".yml,.yaml,.env" webkitdirectory="true" className="hidden" onChange={onImport} />
                         </label>
+
+                        <button
+                            onClick={() => setShowGallery(true)}
+                            className="btn btn-secondary px-5 py-2.5 text-sm flex items-center gap-2"
+                        >
+                            <Compass size={16} />
+                            Explore Examples
+                        </button>
                     </div>
 
                     {/* Drop zone hint */}
@@ -124,6 +134,16 @@ export default function EmptyState({ onImport, onTryDemo, isDragging, setIsDragg
                     ))}
                 </div>
             </div>
+
+            {/* ── Examples Gallery Modal ── */}
+            <ExamplesGallery
+                open={showGallery}
+                onClose={() => setShowGallery(false)}
+                onSelect={(yaml) => {
+                    if (onLoadExample) onLoadExample(yaml);
+                    setShowGallery(false);
+                }}
+            />
         </div>
     );
 }

--- a/src/components/ExampleCard.jsx
+++ b/src/components/ExampleCard.jsx
@@ -1,0 +1,73 @@
+import { Layers } from 'lucide-react';
+
+/**
+ * ExampleCard — Individual card in the gallery representing one compose example.
+ * Displays metadata and triggers selection on click.
+ * 
+ * @param {Object} props
+ * @param {import('../data/examplesGallery').ExampleEntry} props.example - The example metadata
+ * @param {function} props.onSelect - Callback when this card is clicked
+ */
+export default function ExampleCard({ example, onSelect }) {
+    const { name, description, category, tags, serviceCount } = example;
+
+    return (
+        <button
+            onClick={() => onSelect(example)}
+            className="example-card group p-4 rounded-xl surface-raised text-left transition-all duration-200 hover:bg-surface-overlay border border-transparent hover:border-accent/30 w-full"
+        >
+            {/* Header: Name + Service Count */}
+            <div className="flex items-start justify-between gap-2 mb-2">
+                <h3 className="text-sm font-semibold text-text group-hover:text-accent transition-colors leading-tight">
+                    {name}
+                </h3>
+                <span className="flex items-center gap-1 text-xs text-text-tertiary shrink-0" title={`${serviceCount} services`}>
+                    <Layers size={12} />
+                    {serviceCount}
+                </span>
+            </div>
+
+            {/* Description */}
+            <p className="text-xs text-text-secondary leading-relaxed mb-3 line-clamp-2">
+                {description}
+            </p>
+
+            {/* Footer: Category Badge + Tags */}
+            <div className="flex items-center gap-2 flex-wrap">
+                <span className={`example-category-badge px-2 py-0.5 text-[10px] font-medium rounded-full ${getCategoryStyle(category)}`}>
+                    {category}
+                </span>
+                {tags.slice(0, 3).map(tag => (
+                    <span
+                        key={tag}
+                        className="px-1.5 py-0.5 text-[10px] text-text-tertiary bg-surface-overlay rounded"
+                    >
+                        {tag}
+                    </span>
+                ))}
+            </div>
+        </button>
+    );
+}
+
+/**
+ * Get category-specific styling classes
+ * @param {string} category
+ * @returns {string} Tailwind classes
+ */
+function getCategoryStyle(category) {
+    switch (category) {
+        case 'fullstack':
+            return 'bg-accent-muted text-accent';
+        case 'web':
+            return 'bg-success-muted text-success';
+        case 'backend':
+            return 'bg-[rgba(110,159,255,0.15)] text-service';
+        case 'monitoring':
+            return 'bg-[rgba(179,146,240,0.15)] text-secret';
+        case 'database':
+            return 'bg-warning-muted text-warning';
+        default:
+            return 'bg-surface-overlay text-text-secondary';
+    }
+}

--- a/src/components/ExamplesGallery.jsx
+++ b/src/components/ExamplesGallery.jsx
@@ -1,0 +1,356 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { X, Compass, ExternalLink, Info, Globe, Package, Loader2, AlertCircle, RefreshCw } from 'lucide-react';
+import { galleryExamples, CATEGORIES } from '../data/examplesGallery';
+import { fetchRemoteExamplesList, fetchRemoteExampleYaml, fetchRemoteExampleDescription } from '../utils/githubExamples';
+import ExampleCard from './ExampleCard';
+
+/**
+ * ExamplesGallery — Modal that displays Docker Compose examples.
+ * Two sources:
+ *   1. "Curated" tab — 8 static bundled examples (instant, no network)
+ *   2. "Browse All" tab — full awesome-compose repo fetched on-demand from GitHub
+ * 
+ * @param {Object} props
+ * @param {boolean} props.open - Whether the gallery is visible
+ * @param {function} props.onClose - Callback to close the gallery
+ * @param {function} props.onSelect - Callback when an example is chosen: (yamlString, example) => void
+ */
+export default function ExamplesGallery({ open, onClose, onSelect }) {
+    const [activeTab, setActiveTab] = useState('curated'); // 'curated' | 'browse'
+    const [activeCategory, setActiveCategory] = useState('all');
+
+    // Remote examples state
+    const [remoteExamples, setRemoteExamples] = useState([]);
+    const [remoteLoading, setRemoteLoading] = useState(false);
+    const [remoteError, setRemoteError] = useState(null);
+    const [fetchingYaml, setFetchingYaml] = useState(null); // id of example being fetched
+    const [searchTerm, setSearchTerm] = useState('');
+
+    const modalRef = useRef(null);
+    const closeButtonRef = useRef(null);
+
+    const filteredExamples = activeCategory === 'all'
+        ? galleryExamples.filter(e => !searchTerm || e.name.toLowerCase().includes(searchTerm.toLowerCase()) || e.tags.some(t => t.includes(searchTerm.toLowerCase())))
+        : galleryExamples.filter(e => e.category === activeCategory && (!searchTerm || e.name.toLowerCase().includes(searchTerm.toLowerCase()) || e.tags.some(t => t.includes(searchTerm.toLowerCase()))));
+
+    // Filter remote examples by search
+    const filteredRemote = searchTerm
+        ? remoteExamples.filter(e => e.name.toLowerCase().includes(searchTerm.toLowerCase()) || e.id.includes(searchTerm.toLowerCase()))
+        : remoteExamples;
+
+    // Fetch remote listing when "Browse All" tab is activated
+    useEffect(() => {
+        if (activeTab === 'browse' && remoteExamples.length === 0 && !remoteLoading) {
+            loadRemoteExamples();
+        }
+    }, [activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const loadRemoteExamples = async () => {
+        setRemoteLoading(true);
+        setRemoteError(null);
+        try {
+            const examples = await fetchRemoteExamplesList();
+            setRemoteExamples(examples);
+        } catch (err) {
+            setRemoteError(err.message);
+        } finally {
+            setRemoteLoading(false);
+        }
+    };
+
+    // Handle keyboard events (Escape to close)
+    const handleKeyDown = useCallback((e) => {
+        if (e.key === 'Escape') {
+            onClose();
+        }
+    }, [onClose]);
+
+    // Focus management
+    useEffect(() => {
+        if (open) {
+            closeButtonRef.current?.focus();
+            document.addEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = 'hidden';
+        }
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = '';
+        };
+    }, [open, handleKeyDown]);
+
+    // Handle backdrop click
+    const handleBackdropClick = (e) => {
+        if (e.target === e.currentTarget) {
+            onClose();
+        }
+    };
+
+    // Handle curated example selection (instant — YAML is bundled)
+    const handleCuratedSelect = (example) => {
+        onSelect(example.yaml, example);
+    };
+
+    // Handle remote example selection (fetch YAML on-demand)
+    const handleRemoteSelect = async (example) => {
+        setFetchingYaml(example.id);
+        setRemoteError(null);
+        try {
+            const yaml = await fetchRemoteExampleYaml(example.id);
+            onSelect(yaml, { ...example, yaml });
+        } catch (err) {
+            setRemoteError(`Failed to load "${example.name}": ${err.message}`);
+        } finally {
+            setFetchingYaml(null);
+        }
+    };
+
+    if (!open) return null;
+
+    return (
+        <div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4 modal-backdrop"
+            onClick={handleBackdropClick}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="examples-gallery-title"
+        >
+            <div
+                ref={modalRef}
+                className="glass rounded-2xl max-w-2xl w-full max-h-[85vh] flex flex-col modal-content"
+                onClick={e => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between p-5 pb-0">
+                    <div className="flex items-center gap-2">
+                        <Compass size={20} className="text-accent" />
+                        <h2 id="examples-gallery-title" className="text-lg font-bold text-text">
+                            Explore Examples
+                        </h2>
+                    </div>
+                    <button
+                        ref={closeButtonRef}
+                        onClick={onClose}
+                        className="p-2 hover:bg-surface-raised rounded-lg transition-colors text-text-secondary hover:text-text"
+                        aria-label="Close gallery"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {/* Disclaimer */}
+                <div className="px-5 pt-3">
+                    <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-accent-muted/50 border border-accent/20">
+                        <Info size={14} className="text-accent mt-0.5 shrink-0" />
+                        <p className="text-xs text-text-secondary leading-relaxed">
+                            These examples are for <strong className="text-text">visualization only</strong>.
+                            Select one to explore its architecture as an interactive diagram.
+                            <span className="ml-1 text-text-tertiary">
+                                Sourced from{' '}
+                                <a
+                                    href="https://github.com/docker/awesome-compose"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-accent hover:underline inline-flex items-center gap-0.5"
+                                >
+                                    awesome-compose
+                                    <ExternalLink size={10} />
+                                </a>
+                            </span>
+                        </p>
+                    </div>
+                </div>
+
+                {/* Source Tabs: Curated vs Browse All */}
+                <div className="px-5 pt-4 pb-2">
+                    <div className="flex gap-1 p-1 bg-surface-raised rounded-lg w-fit">
+                        <button
+                            onClick={() => setActiveTab('curated')}
+                            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors flex items-center gap-1.5 ${
+                                activeTab === 'curated'
+                                    ? 'bg-accent text-white shadow-sm'
+                                    : 'text-text-secondary hover:text-text'
+                            }`}
+                        >
+                            <Package size={12} />
+                            Curated
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('browse')}
+                            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors flex items-center gap-1.5 ${
+                                activeTab === 'browse'
+                                    ? 'bg-accent text-white shadow-sm'
+                                    : 'text-text-secondary hover:text-text'
+                            }`}
+                        >
+                            <Globe size={12} />
+                            Browse All
+                            {remoteExamples.length > 0 && (
+                                <span className="text-[10px] opacity-75">({remoteExamples.length})</span>
+                            )}
+                        </button>
+                    </div>
+                </div>
+
+                {/* Tab Content */}
+                {activeTab === 'curated' ? (
+                    <>
+                        {/* Category Filter + Search (curated) */}
+                        <div className="px-5 pb-2 space-y-2">
+                            <input
+                                type="text"
+                                placeholder="Search curated examples..."
+                                value={searchTerm}
+                                onChange={e => setSearchTerm(e.target.value)}
+                                className="w-full px-3 py-2 text-sm rounded-lg bg-surface-raised border border-border/50 focus:border-accent/50 focus:outline-none text-text placeholder:text-text-tertiary"
+                            />
+                            <div className="flex gap-1.5 flex-wrap" role="tablist" aria-label="Filter by category">
+                                {CATEGORIES.map(cat => (
+                                    <button
+                                        key={cat}
+                                        onClick={() => setActiveCategory(cat)}
+                                        role="tab"
+                                        aria-selected={activeCategory === cat}
+                                        className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors capitalize ${
+                                            activeCategory === cat
+                                                ? 'bg-accent text-white'
+                                                : 'bg-surface-raised text-text-secondary hover:text-text hover:bg-surface-overlay'
+                                        }`}
+                                    >
+                                        {cat}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* Curated Examples Grid */}
+                        <div className="flex-1 overflow-auto px-5 pb-5 pt-2" role="tabpanel">
+                            {filteredExamples.length === 0 ? (
+                                <EmptyFilterState />
+                            ) : (
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                    {filteredExamples.map(example => (
+                                        <ExampleCard
+                                            key={example.id}
+                                            example={example}
+                                            onSelect={handleCuratedSelect}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        {/* Search (browse tab) */}
+                        <div className="px-5 pb-2">
+                            <input
+                                type="text"
+                                placeholder="Search examples..."
+                                value={searchTerm}
+                                onChange={e => setSearchTerm(e.target.value)}
+                                className="w-full px-3 py-2 text-sm rounded-lg bg-surface-raised border border-border/50 focus:border-accent/50 focus:outline-none text-text placeholder:text-text-tertiary"
+                            />
+                        </div>
+
+                        {/* Remote Examples List */}
+                        <div className="flex-1 overflow-auto px-5 pb-5 pt-2">
+                            {remoteLoading ? (
+                                <div className="flex flex-col items-center justify-center py-12 text-center">
+                                    <Loader2 size={24} className="text-accent animate-spin mb-3" />
+                                    <p className="text-sm text-text-secondary">Loading examples from GitHub...</p>
+                                </div>
+                            ) : remoteError ? (
+                                <div className="flex flex-col items-center justify-center py-12 text-center">
+                                    <AlertCircle size={24} className="text-error mb-3" />
+                                    <p className="text-sm text-text-secondary mb-3">{remoteError}</p>
+                                    <button
+                                        onClick={loadRemoteExamples}
+                                        className="btn btn-secondary text-xs flex items-center gap-1.5"
+                                    >
+                                        <RefreshCw size={12} />
+                                        Retry
+                                    </button>
+                                </div>
+                            ) : filteredRemote.length === 0 ? (
+                                <EmptyFilterState />
+                            ) : (
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                    {filteredRemote.map(example => (
+                                        <RemoteExampleItem
+                                            key={example.id}
+                                            example={example}
+                                            onSelect={handleRemoteSelect}
+                                            isLoading={fetchingYaml === example.id}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+/**
+ * RemoteExampleItem — Compact card for remote (on-demand) examples.
+ * Shows a loading spinner when its YAML is being fetched.
+ * Fetches description from README on hover for richer display.
+ */
+function RemoteExampleItem({ example, onSelect, isLoading }) {
+    const [description, setDescription] = useState(null);
+    const hasFetched = useRef(false);
+
+    const handleMouseEnter = async () => {
+        if (hasFetched.current || description) return;
+        hasFetched.current = true;
+        try {
+            const desc = await fetchRemoteExampleDescription(example.id);
+            if (desc) setDescription(desc);
+        } catch {
+            // Silently fail — description is optional
+        }
+    };
+
+    return (
+        <button
+            onClick={() => !isLoading && onSelect(example)}
+            onMouseEnter={handleMouseEnter}
+            disabled={isLoading}
+            className="group p-3 rounded-lg surface-raised text-left transition-all duration-150 hover:bg-surface-overlay border border-transparent hover:border-accent/30 w-full disabled:opacity-60 disabled:cursor-wait flex items-center gap-3"
+        >
+            <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-text group-hover:text-accent transition-colors truncate">
+                    {example.name}
+                </p>
+                {description ? (
+                    <p className="text-[11px] text-text-secondary truncate mt-0.5 leading-relaxed">
+                        {description}
+                    </p>
+                ) : (
+                    <p className="text-[11px] text-text-tertiary truncate mt-0.5">
+                        {example.id}
+                    </p>
+                )}
+            </div>
+            {isLoading ? (
+                <Loader2 size={14} className="text-accent animate-spin shrink-0" />
+            ) : (
+                <Globe size={12} className="text-text-tertiary shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+            )}
+        </button>
+    );
+}
+
+/**
+ * Empty state shown when no examples match the current filter/search.
+ */
+function EmptyFilterState() {
+    return (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+            <Compass size={32} className="text-text-tertiary mb-3" />
+            <p className="text-sm text-text-secondary">No examples match your search.</p>
+        </div>
+    );
+}

--- a/src/components/ExamplesGallery.test.jsx
+++ b/src/components/ExamplesGallery.test.jsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExamplesGallery from './ExamplesGallery';
+import ExampleCard from './ExampleCard';
+import { galleryExamples } from '../data/examplesGallery';
+
+// Mock the GitHub fetcher to avoid real network calls
+vi.mock('../utils/githubExamples', () => ({
+    fetchRemoteExamplesList: vi.fn().mockResolvedValue([]),
+    fetchRemoteExampleYaml: vi.fn().mockResolvedValue('services:\n  web:\n    image: nginx'),
+    fetchRemoteExampleDescription: vi.fn().mockResolvedValue(null),
+    clearCache: vi.fn(),
+}));
+
+const mockExample = {
+    id: 'test-example',
+    name: 'Test Example',
+    description: 'A test compose example for unit testing.',
+    category: 'fullstack',
+    tags: ['nginx', 'node', 'postgres'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/test',
+    yaml: 'services:\n  web:\n    image: nginx\n  api:\n    image: node\n  db:\n    image: postgres'
+};
+
+describe('ExampleCard', () => {
+    it('renders with correct data', () => {
+        const onSelect = vi.fn();
+        render(<ExampleCard example={mockExample} onSelect={onSelect} />);
+
+        expect(screen.getByText('Test Example')).toBeInTheDocument();
+        expect(screen.getByText('A test compose example for unit testing.')).toBeInTheDocument();
+        expect(screen.getByText('fullstack')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('displays technology tags', () => {
+        const onSelect = vi.fn();
+        render(<ExampleCard example={mockExample} onSelect={onSelect} />);
+
+        expect(screen.getByText('nginx')).toBeInTheDocument();
+        expect(screen.getByText('node')).toBeInTheDocument();
+        expect(screen.getByText('postgres')).toBeInTheDocument();
+    });
+
+    it('triggers onSelect callback when clicked', () => {
+        const onSelect = vi.fn();
+        render(<ExampleCard example={mockExample} onSelect={onSelect} />);
+
+        fireEvent.click(screen.getByRole('button'));
+        expect(onSelect).toHaveBeenCalledWith(mockExample);
+    });
+
+    it('limits displayed tags to 3', () => {
+        const manyTags = { ...mockExample, tags: ['a', 'b', 'c', 'd', 'e'] };
+        const onSelect = vi.fn();
+        render(<ExampleCard example={manyTags} onSelect={onSelect} />);
+
+        expect(screen.getByText('a')).toBeInTheDocument();
+        expect(screen.getByText('b')).toBeInTheDocument();
+        expect(screen.getByText('c')).toBeInTheDocument();
+        expect(screen.queryByText('d')).not.toBeInTheDocument();
+    });
+});
+
+describe('ExamplesGallery', () => {
+    it('renders nothing when closed', () => {
+        const { container } = render(
+            <ExamplesGallery open={false} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders modal when open', () => {
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+        expect(screen.getByText('Explore Examples')).toBeInTheDocument();
+    });
+
+    it('renders list of example cards', () => {
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+
+        // Should render all gallery examples by default (category 'all')
+        for (const example of galleryExamples) {
+            expect(screen.getByText(example.name)).toBeInTheDocument();
+        }
+    });
+
+    it('category filtering works', () => {
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+
+        // Click on 'monitoring' filter
+        fireEvent.click(screen.getByRole('tab', { name: /monitoring/i }));
+
+        // Should show monitoring examples
+        const monitoringExamples = galleryExamples.filter(e => e.category === 'monitoring');
+        for (const example of monitoringExamples) {
+            expect(screen.getByText(example.name)).toBeInTheDocument();
+        }
+
+        // Should NOT show non-monitoring examples
+        const nonMonitoring = galleryExamples.filter(e => e.category !== 'monitoring');
+        for (const example of nonMonitoring) {
+            expect(screen.queryByText(example.name)).not.toBeInTheDocument();
+        }
+    });
+
+    it('close button calls onClose', () => {
+        const onClose = vi.fn();
+        render(
+            <ExamplesGallery open={true} onClose={onClose} onSelect={vi.fn()} />
+        );
+
+        fireEvent.click(screen.getByLabelText('Close gallery'));
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('backdrop click calls onClose', () => {
+        const onClose = vi.fn();
+        render(
+            <ExamplesGallery open={true} onClose={onClose} onSelect={vi.fn()} />
+        );
+
+        fireEvent.click(screen.getByRole('dialog'));
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('Escape key calls onClose', () => {
+        const onClose = vi.fn();
+        render(
+            <ExamplesGallery open={true} onClose={onClose} onSelect={vi.fn()} />
+        );
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('onSelect callback fires with YAML when example is clicked', () => {
+        const onSelect = vi.fn();
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={onSelect} />
+        );
+
+        // Click the first example card
+        const firstExample = galleryExamples[0];
+        fireEvent.click(screen.getByText(firstExample.name));
+
+        expect(onSelect).toHaveBeenCalledWith(firstExample.yaml, firstExample);
+    });
+
+    it('shows visualization-only disclaimer', () => {
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+
+        expect(screen.getByText(/visualization only/i)).toBeInTheDocument();
+    });
+
+    it('shows empty state for category with no examples', () => {
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+
+        // Click on 'database' filter (no examples in this category currently)
+        fireEvent.click(screen.getByRole('tab', { name: /database/i }));
+        expect(screen.getByText(/no examples match/i)).toBeInTheDocument();
+    });
+
+    it('has proper ARIA attributes', () => {
+        render(
+            <ExamplesGallery open={true} onClose={vi.fn()} onSelect={vi.fn()} />
+        );
+
+        const dialog = screen.getByRole('dialog');
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(dialog).toHaveAttribute('aria-labelledby', 'examples-gallery-title');
+    });
+});

--- a/src/components/MainLayout.jsx
+++ b/src/components/MainLayout.jsx
@@ -112,6 +112,13 @@ export default function MainLayout() {
         }
     };
 
+    // Load example from gallery
+    const handleLoadExample = async (yaml, example) => {
+        await handleImport(yaml, [], { exampleDir: example?.id || null });
+        setActiveView('build');
+        toast.success('Example loaded — explore the architecture!');
+    };
+
     // File import handler for EmptyState
     const handleFileImport = async (e) => {
         const files = Array.from(e.target.files || []).filter((file) => (
@@ -152,6 +159,7 @@ export default function MainLayout() {
             <EmptyState
                 onImport={handleFileImport}
                 onTryDemo={handleTryDemo}
+                onLoadExample={handleLoadExample}
                 isDragging={isDragging}
                 setIsDragging={setIsDragging}
                 onDrop={handleFileDrop}

--- a/src/data/examplesGallery.includes.test.js
+++ b/src/data/examplesGallery.includes.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { parseCompose } from '../utils/composeParser.js';
+import { galleryExamples } from './examplesGallery.js';
+
+/**
+ * Tests for include resolution support in gallery examples.
+ * Validates that examples with the `includes` field resolve correctly.
+ */
+describe('Examples Gallery - Include Resolution', () => {
+    // Get examples that have includes
+    const examplesWithIncludes = galleryExamples.filter(e => e.includes);
+
+    describe('examples with includes field', () => {
+        it('all referenced paths in include directives exist in includes object', () => {
+            for (const example of examplesWithIncludes) {
+                // Parse the YAML to find include directives
+                const parsed = yaml.load(example.yaml);
+
+                if (parsed.include) {
+                    const includes = Array.isArray(parsed.include) ? parsed.include : [parsed.include];
+                    for (const inc of includes) {
+                        const path = typeof inc === 'string' ? inc : inc.path;
+                        expect(
+                            example.includes[path],
+                            `${example.id}: include path "${path}" not found in includes object`
+                        ).toBeDefined();
+                    }
+                }
+            }
+        });
+
+        it('parsing with fileMap produces merged compose with all services', () => {
+            for (const example of examplesWithIncludes) {
+                const fileMap = {
+                    'compose.yaml': example.yaml,
+                    ...example.includes
+                };
+
+                const result = parseCompose(example.yaml, {
+                    basePath: 'compose.yaml',
+                    fileMap,
+                    enableIncludes: true,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result.compose, `${example.id} failed to parse with includes`).not.toBeNull();
+                const serviceCount = Object.keys(result.compose.services || {}).length;
+                expect(serviceCount, `${example.id}: expected ${example.serviceCount} services after include resolution`).toBe(example.serviceCount);
+            }
+        });
+
+        it('included file YAML is valid', () => {
+            for (const example of examplesWithIncludes) {
+                for (const [path, content] of Object.entries(example.includes)) {
+                    const parsed = yaml.load(content);
+                    expect(parsed, `${example.id}: include "${path}" has invalid YAML`).not.toBeNull();
+                }
+            }
+        });
+    });
+
+    describe('examples without includes', () => {
+        const examplesWithoutIncludes = galleryExamples.filter(e => !e.includes);
+
+        it('parse correctly without fileMap', () => {
+            for (const example of examplesWithoutIncludes) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result.compose, `${example.id} failed without includes`).not.toBeNull();
+            }
+        });
+    });
+
+    describe('fileMap integration via loadFiles override', () => {
+        it('empty fileMap does not break parsing', () => {
+            for (const example of galleryExamples) {
+                const result = parseCompose(example.yaml, {
+                    fileMap: {},
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result.compose, `${example.id} broke with empty fileMap`).not.toBeNull();
+            }
+        });
+    });
+});

--- a/src/data/examplesGallery.integration.test.js
+++ b/src/data/examplesGallery.integration.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { parseCompose } from '../utils/composeParser.js';
+import { generateGraphviz } from '../utils/graphviz.js';
+import { galleryExamples } from './examplesGallery.js';
+
+/**
+ * Integration tests: Verify gallery examples work end-to-end
+ * through the actual parser and graphviz pipeline.
+ */
+describe('Examples Gallery Integration', () => {
+    describe('full pipeline: parse → graphviz', () => {
+        it('every example produces a non-null compose object', () => {
+            for (const example of galleryExamples) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result.compose, `${example.id} produced null compose`).not.toBeNull();
+                expect(result.compose.services, `${example.id} has no services`).toBeDefined();
+            }
+        });
+
+        it('every example generates non-empty graphviz DOT', () => {
+            for (const example of galleryExamples) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                const dot = generateGraphviz(result.compose);
+                expect(dot, `${example.id} produced empty DOT`).toBeTruthy();
+                expect(dot.length, `${example.id} DOT too short`).toBeGreaterThan(10);
+                expect(dot).toContain('digraph');
+            }
+        });
+
+        it('example loads and diagram renders with correct service count', () => {
+            for (const example of galleryExamples) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                const serviceCount = Object.keys(result.compose.services || {}).length;
+                expect(serviceCount, `${example.id}: expected ${example.serviceCount} services`).toBe(example.serviceCount);
+            }
+        });
+
+        it('no example produces fatal errors', () => {
+            for (const example of galleryExamples) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                const fatalErrors = (result.errors || []).filter(e => e.type === 'fatal' || e.type === 'error');
+                expect(fatalErrors, `${example.id} has fatal errors: ${JSON.stringify(fatalErrors)}`).toHaveLength(0);
+            }
+        });
+    });
+
+    describe('idempotent loading', () => {
+        it('loading same example twice produces identical state', () => {
+            for (const example of galleryExamples) {
+                const result1 = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                const result2 = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result1.compose, `${example.id} not idempotent`).toEqual(result2.compose);
+            }
+        });
+    });
+
+    describe('non-destructive loading', () => {
+        it('loading different examples produces different states', () => {
+            if (galleryExamples.length < 2) return;
+
+            const result1 = parseCompose(galleryExamples[0].yaml, {
+                enableIncludes: false,
+                enableExtends: true,
+                enableVariables: true,
+                enableProfiles: false
+            });
+
+            const result2 = parseCompose(galleryExamples[1].yaml, {
+                enableIncludes: false,
+                enableExtends: true,
+                enableVariables: true,
+                enableProfiles: false
+            });
+
+            // Different examples should produce different service sets
+            const services1 = Object.keys(result1.compose.services);
+            const services2 = Object.keys(result2.compose.services);
+            expect(services1).not.toEqual(services2);
+        });
+    });
+
+    describe('error tolerance', () => {
+        it('examples with build-only services still parse', () => {
+            // Several examples have build: without image:
+            const buildExamples = galleryExamples.filter(e =>
+                e.yaml.includes('build:')
+            );
+
+            for (const example of buildExamples) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result.compose, `${example.id} failed with build-only services`).not.toBeNull();
+            }
+        });
+
+        it('examples with secrets still parse', () => {
+            const secretExamples = galleryExamples.filter(e =>
+                e.yaml.includes('secrets:')
+            );
+
+            for (const example of secretExamples) {
+                const result = parseCompose(example.yaml, {
+                    enableIncludes: false,
+                    enableExtends: true,
+                    enableVariables: true,
+                    enableProfiles: false
+                });
+
+                expect(result.compose, `${example.id} failed with secrets`).not.toBeNull();
+                expect(result.compose.secrets).toBeDefined();
+            }
+        });
+    });
+});

--- a/src/data/examplesGallery.js
+++ b/src/data/examplesGallery.js
@@ -1,0 +1,488 @@
+/**
+ * Curated Docker Compose examples for the Examples Gallery.
+ * Sourced from docker/awesome-compose (MIT licensed).
+ * 
+ * @see https://github.com/docker/awesome-compose
+ * 
+ * @typedef {Object} ExampleEntry
+ * @property {string} id - Unique identifier (kebab-case)
+ * @property {string} name - Display name
+ * @property {string} description - Short description (1-2 sentences)
+ * @property {string} category - Primary category: 'web' | 'backend' | 'fullstack' | 'monitoring' | 'database'
+ * @property {string[]} tags - Technology tags for display (e.g., ['nginx', 'node', 'postgres'])
+ * @property {number} serviceCount - Number of services in the example
+ * @property {string} source - Attribution URL from awesome-compose
+ * @property {string} yaml - Raw docker-compose.yml content as string
+ * @property {Object<string, string>} [includes] - Optional map of included file paths to their YAML content
+ */
+
+/** @type {ExampleEntry[]} */
+export const galleryExamples = [
+  {
+    id: 'react-express-mongodb',
+    name: 'React + Express + MongoDB',
+    description: 'Full-stack JavaScript app with React frontend, Express API, and MongoDB database.',
+    category: 'fullstack',
+    tags: ['react', 'node', 'mongodb'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/react-express-mongodb',
+    yaml: `services:
+  frontend:
+    build:
+      context: frontend
+      target: development
+    ports:
+      - 3000:3000
+    stdin_open: true
+    volumes:
+      - ./frontend:/usr/src/app
+      - /usr/src/app/node_modules
+    restart: always
+    networks:
+      - react-express
+    depends_on:
+      - backend
+
+  backend:
+    restart: always
+    build:
+      context: backend
+      target: development
+    volumes:
+      - ./backend:/usr/src/app
+      - /usr/src/app/node_modules
+    depends_on:
+      - mongo
+    networks:
+      - express-mongo
+      - react-express
+    expose:
+      - 3000
+
+  mongo:
+    restart: always
+    image: mongo:4.2.0
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - express-mongo
+    expose:
+      - 27017
+
+networks:
+  react-express:
+  express-mongo:
+
+volumes:
+  mongo_data:`
+  },
+  {
+    id: 'nginx-golang-postgres',
+    name: 'Nginx + Go + PostgreSQL',
+    description: 'Three-tier web app with Nginx reverse proxy, Go backend, and PostgreSQL database with health checks.',
+    category: 'fullstack',
+    tags: ['nginx', 'golang', 'postgresql'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/nginx-golang-postgres',
+    yaml: `services:
+  backend:
+    build:
+      context: backend
+      target: builder
+    secrets:
+      - db-password
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres
+    restart: always
+    user: postgres
+    secrets:
+      - db-password
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=example
+      - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+    expose:
+      - 5432
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  proxy:
+    image: nginx
+    volumes:
+      - type: bind
+        source: ./proxy/nginx.conf
+        target: /etc/nginx/conf.d/default.conf
+        read_only: true
+    ports:
+      - 80:80
+    depends_on:
+      - backend
+
+volumes:
+  db-data:
+
+secrets:
+  db-password:
+    file: db/password.txt`
+  },
+  {
+    id: 'nginx-flask-mysql',
+    name: 'Nginx + Flask + MySQL',
+    description: 'Python Flask backend with Nginx reverse proxy and MySQL database, using secrets and health checks.',
+    category: 'fullstack',
+    tags: ['nginx', 'python', 'mysql'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/nginx-flask-mysql',
+    yaml: `services:
+  db:
+    image: mariadb:10-focal
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 --password="$$(cat /run/secrets/db-password)" --silent']
+      interval: 3s
+      retries: 5
+      start_period: 30s
+    secrets:
+      - db-password
+    volumes:
+      - db-data:/var/lib/mysql
+    networks:
+      - backnet
+    environment:
+      - MYSQL_DATABASE=example
+      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/db-password
+    expose:
+      - 3306
+      - 33060
+
+  backend:
+    build:
+      context: backend
+      target: builder
+    restart: always
+    secrets:
+      - db-password
+    ports:
+      - 8000:8000
+    networks:
+      - backnet
+      - frontnet
+    depends_on:
+      db:
+        condition: service_healthy
+
+  proxy:
+    build: proxy
+    restart: always
+    ports:
+      - 80:80
+    depends_on:
+      - backend
+    networks:
+      - frontnet
+
+volumes:
+  db-data:
+
+secrets:
+  db-password:
+    file: db/password.txt
+
+networks:
+  backnet:
+  frontnet:`
+  },
+  {
+    id: 'react-rust-postgres',
+    name: 'React + Rust + PostgreSQL',
+    description: 'Modern full-stack with React frontend, Rust backend, and PostgreSQL with isolated networks.',
+    category: 'fullstack',
+    tags: ['react', 'rust', 'postgresql'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/react-rust-postgres',
+    yaml: `name: react-rust-postgres
+
+services:
+  frontend:
+    build:
+      context: frontend
+      target: development
+    networks:
+      - client-side
+    ports:
+      - 3000:3000
+    volumes:
+      - ./frontend/src:/code/src:ro
+
+  backend:
+    build:
+      context: backend
+      target: development
+    environment:
+      - ADDRESS=0.0.0.0:8000
+      - RUST_LOG=debug
+      - PG_DBNAME=postgres
+      - PG_HOST=db
+      - PG_USER=postgres
+      - PG_PASSWORD=mysecretpassword
+    networks:
+      - client-side
+      - server-side
+    volumes:
+      - ./backend/src:/code/src
+      - backend-cache:/code/target
+    depends_on:
+      - db
+
+  db:
+    image: postgres:12-alpine
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD=mysecretpassword
+    networks:
+      - server-side
+    ports:
+      - 5432:5432
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+networks:
+  client-side: {}
+  server-side: {}
+
+volumes:
+  backend-cache: {}
+  db-data: {}`
+  },
+  {
+    id: 'wordpress-mysql',
+    name: 'WordPress + MySQL',
+    description: 'Classic WordPress CMS with MariaDB database backend. Simple two-service setup.',
+    category: 'web',
+    tags: ['php', 'mysql'],
+    serviceCount: 2,
+    source: 'https://github.com/docker/awesome-compose/tree/master/wordpress-mysql',
+    yaml: `services:
+  db:
+    image: mariadb:10.6.4-focal
+    command: '--default-authentication-plugin=mysql_native_password'
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+    expose:
+      - 3306
+      - 33060
+
+  wordpress:
+    image: wordpress:latest
+    ports:
+      - 80:80
+    restart: always
+    environment:
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=wordpress
+      - WORDPRESS_DB_PASSWORD=wordpress
+      - WORDPRESS_DB_NAME=wordpress
+
+volumes:
+  db_data:`
+  },
+  {
+    id: 'prometheus-grafana',
+    name: 'Prometheus + Grafana',
+    description: 'Monitoring stack with Prometheus metrics collection and Grafana dashboards.',
+    category: 'monitoring',
+    tags: ['prometheus', 'grafana'],
+    serviceCount: 2,
+    source: 'https://github.com/docker/awesome-compose/tree/master/prometheus-grafana',
+    yaml: `services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prom_data:/prometheus
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./grafana:/etc/grafana/provisioning/datasources
+
+volumes:
+  prom_data:`
+  },
+  {
+    id: 'elasticsearch-logstash-kibana',
+    name: 'ELK Stack',
+    description: 'Elasticsearch, Logstash, and Kibana for centralized logging and search analytics.',
+    category: 'monitoring',
+    tags: ['elasticsearch', 'logstash', 'kibana'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/elasticsearch-logstash-kibana',
+    yaml: `services:
+  elasticsearch:
+    image: elasticsearch:7.16.1
+    container_name: es
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    networks:
+      - elastic
+
+  logstash:
+    image: logstash:7.16.1
+    container_name: log
+    environment:
+      discovery.seed_hosts: logstash
+      LS_JAVA_OPTS: "-Xms512m -Xmx512m"
+    volumes:
+      - ./logstash/pipeline/logstash-nginx.config:/usr/share/logstash/pipeline/logstash-nginx.config
+      - ./logstash/nginx.log:/home/nginx.log
+    ports:
+      - "5000:5000/tcp"
+      - "5000:5000/udp"
+      - "5044:5044"
+      - "9600:9600"
+    depends_on:
+      - elasticsearch
+    networks:
+      - elastic
+    command: logstash -f /usr/share/logstash/pipeline/logstash-nginx.config
+
+  kibana:
+    image: kibana:7.16.1
+    container_name: kib
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - elastic
+
+networks:
+  elastic:
+    driver: bridge`
+  },
+  {
+    id: 'nextcloud-redis-mariadb',
+    name: 'Nextcloud + Redis + MariaDB',
+    description: 'Self-hosted cloud storage with Redis caching and MariaDB, using isolated networks.',
+    category: 'web',
+    tags: ['nextcloud', 'redis', 'mysql'],
+    serviceCount: 3,
+    source: 'https://github.com/docker/awesome-compose/tree/master/nextcloud-redis-mariadb',
+    yaml: `services:
+  nc:
+    image: nextcloud:apache
+    restart: always
+    ports:
+      - 80:80
+    volumes:
+      - nc_data:/var/www/html
+    networks:
+      - redisnet
+      - dbnet
+    environment:
+      - REDIS_HOST=redis
+      - MYSQL_HOST=db
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_PASSWORD=nextcloud
+
+  redis:
+    image: redis:alpine
+    restart: always
+    networks:
+      - redisnet
+    expose:
+      - 6379
+
+  db:
+    image: mariadb:10.5
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+    networks:
+      - dbnet
+    environment:
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_ROOT_PASSWORD=nextcloud
+      - MYSQL_PASSWORD=nextcloud
+    expose:
+      - 3306
+
+volumes:
+  db_data:
+  nc_data:
+
+networks:
+  dbnet:
+  redisnet:`
+  }
+];
+
+/**
+ * Valid categories for filtering
+ */
+export const CATEGORIES = ['all', 'web', 'backend', 'fullstack', 'monitoring', 'database'];
+
+/**
+ * Filter examples by category.
+ * 
+ * @param {ExampleEntry[]} examples - Array of examples to filter
+ * @param {string} category - Category to filter by ('all' returns everything)
+ * @returns {ExampleEntry[]} Filtered array (original not mutated, order preserved)
+ */
+export function filterExamples(examples, category) {
+  if (category === 'all') return examples;
+  return examples.filter(ex => ex.category === category);
+}
+
+/**
+ * Get all gallery examples sorted by category then name.
+ * 
+ * @returns {ExampleEntry[]} Sorted array of all examples
+ */
+export function getExamplesGallery() {
+  return [...galleryExamples].sort((a, b) => {
+    const catCompare = a.category.localeCompare(b.category);
+    if (catCompare !== 0) return catCompare;
+    return a.name.localeCompare(b.name);
+  });
+}

--- a/src/data/examplesGallery.property.test.js
+++ b/src/data/examplesGallery.property.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { parseCompose } from '../utils/composeParser.js';
+import { generateGraphviz } from '../utils/graphviz.js';
+import { galleryExamples, filterExamples, CATEGORIES } from './examplesGallery.js';
+
+/**
+ * Property-based tests for the Examples Gallery.
+ * These verify formal correctness properties that must hold
+ * for all inputs and all examples.
+ */
+describe('Examples Gallery - Correctness Properties', () => {
+    /**
+     * Property 1: Gallery completeness
+     * ∀ entry ∈ galleryExamples: parseCompose(entry.yaml).compose !== null
+     */
+    it('PROPERTY: Every example produces non-null compose object', () => {
+        for (const example of galleryExamples) {
+            const result = parseCompose(example.yaml, {
+                enableIncludes: false,
+                enableExtends: true,
+                enableVariables: true,
+                enableProfiles: false
+            });
+            expect(result.compose, `Failed for ${example.id}`).not.toBeNull();
+        }
+    });
+
+    /**
+     * Property 2: Every example generates non-empty graphviz DOT
+     * ∀ entry ∈ galleryExamples: generateGraphviz(parseCompose(entry.yaml).compose).length > 0
+     */
+    it('PROPERTY: Loading any example generates non-empty graphviz DOT', () => {
+        for (const example of galleryExamples) {
+            const result = parseCompose(example.yaml, {
+                enableIncludes: false,
+                enableExtends: true,
+                enableVariables: true,
+                enableProfiles: false
+            });
+            const dot = generateGraphviz(result.compose);
+            expect(dot.length, `Failed for ${example.id}`).toBeGreaterThan(0);
+        }
+    });
+
+    /**
+     * Property 3: Category filter correctness
+     * ∀ category, ∀ entry ∈ filterExamples(examples, category):
+     *   entry.category === category ∨ category === 'all'
+     * 
+     * Additionally: filtering then counting equals sum of individual category counts
+     */
+    it('PROPERTY: Filtering then counting equals sum of category counts', () => {
+        const validCategories = CATEGORIES.filter(c => c !== 'all');
+
+        // Sum of all individual category filters should equal total
+        let totalFromCategories = 0;
+        for (const cat of validCategories) {
+            const filtered = filterExamples(galleryExamples, cat);
+            totalFromCategories += filtered.length;
+
+            // Every item in filtered result must match the category
+            for (const item of filtered) {
+                expect(item.category, `Item ${item.id} doesn't match category ${cat}`).toBe(cat);
+            }
+        }
+
+        // Sum should equal total
+        expect(totalFromCategories).toBe(galleryExamples.length);
+
+        // 'all' should return everything
+        const allFiltered = filterExamples(galleryExamples, 'all');
+        expect(allFiltered.length).toBe(galleryExamples.length);
+    });
+
+    /**
+     * Property 4: Idempotent loading
+     * loadExample(e) → state1; loadExample(e) → state2; state1 === state2
+     */
+    it('PROPERTY: Loading same example twice produces identical state', () => {
+        for (const example of galleryExamples) {
+            const opts = {
+                enableIncludes: false,
+                enableExtends: true,
+                enableVariables: true,
+                enableProfiles: false
+            };
+
+            const state1 = parseCompose(example.yaml, opts).compose;
+            const state2 = parseCompose(example.yaml, opts).compose;
+
+            expect(state1, `Not idempotent for ${example.id}`).toEqual(state2);
+        }
+    });
+
+    /**
+     * Property 5: Filter is a partition
+     * The union of all category filters equals the full set,
+     * and categories are disjoint (no item in two categories).
+     */
+    it('PROPERTY: Categories form a disjoint partition of all examples', () => {
+        const validCategories = CATEGORIES.filter(c => c !== 'all');
+        const seen = new Set();
+
+        for (const cat of validCategories) {
+            const filtered = filterExamples(galleryExamples, cat);
+            for (const item of filtered) {
+                expect(seen.has(item.id), `${item.id} appears in multiple categories`).toBe(false);
+                seen.add(item.id);
+            }
+        }
+
+        // All items should be accounted for
+        expect(seen.size).toBe(galleryExamples.length);
+    });
+
+    /**
+     * Property 6: Filter preserves order
+     * ∀ category: filterExamples(examples, category) preserves relative order from original
+     */
+    it('PROPERTY: Filter preserves relative order from original array', () => {
+        const validCategories = CATEGORIES.filter(c => c !== 'all');
+
+        for (const cat of validCategories) {
+            const filtered = filterExamples(galleryExamples, cat);
+            if (filtered.length < 2) continue;
+
+            for (let i = 0; i < filtered.length - 1; i++) {
+                const idx1 = galleryExamples.indexOf(filtered[i]);
+                const idx2 = galleryExamples.indexOf(filtered[i + 1]);
+                expect(idx1, `Order not preserved for ${cat}`).toBeLessThan(idx2);
+            }
+        }
+    });
+
+    /**
+     * Property 7: Non-mutating filter
+     * filterExamples never modifies the input array
+     */
+    it('PROPERTY: filterExamples is non-mutating', () => {
+        const originalLength = galleryExamples.length;
+        const originalFirst = galleryExamples[0];
+
+        // Run all possible filters
+        for (const cat of CATEGORIES) {
+            filterExamples(galleryExamples, cat);
+        }
+
+        expect(galleryExamples.length).toBe(originalLength);
+        expect(galleryExamples[0]).toBe(originalFirst);
+    });
+});

--- a/src/data/examplesGallery.test.js
+++ b/src/data/examplesGallery.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { galleryExamples, filterExamples, getExamplesGallery, CATEGORIES } from './examplesGallery';
+
+describe('examplesGallery data', () => {
+    describe('data integrity', () => {
+        it('has between 5 and 10 examples', () => {
+            expect(galleryExamples.length).toBeGreaterThanOrEqual(5);
+            expect(galleryExamples.length).toBeLessThanOrEqual(10);
+        });
+
+        it('all examples have required fields', () => {
+            const requiredFields = ['id', 'name', 'description', 'category', 'tags', 'serviceCount', 'source', 'yaml'];
+            for (const example of galleryExamples) {
+                for (const field of requiredFields) {
+                    expect(example[field], `${example.id} missing field: ${field}`).toBeDefined();
+                }
+            }
+        });
+
+        it('all example IDs are unique', () => {
+            const ids = galleryExamples.map(e => e.id);
+            const uniqueIds = new Set(ids);
+            expect(uniqueIds.size).toBe(ids.length);
+        });
+
+        it('all IDs follow kebab-case convention', () => {
+            const kebabRegex = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+            for (const example of galleryExamples) {
+                expect(example.id).toMatch(kebabRegex);
+            }
+        });
+
+        it('all YAML strings parse without fatal errors', () => {
+            for (const example of galleryExamples) {
+                const parsed = yaml.load(example.yaml);
+                expect(parsed, `${example.id} YAML parse failed`).not.toBeNull();
+                expect(parsed.services, `${example.id} has no services`).toBeDefined();
+            }
+        });
+
+        it('serviceCount matches actual services in YAML', () => {
+            for (const example of galleryExamples) {
+                const parsed = yaml.load(example.yaml);
+                const actualCount = Object.keys(parsed.services).length;
+                expect(actualCount, `${example.id}: expected ${example.serviceCount} services, got ${actualCount}`).toBe(example.serviceCount);
+            }
+        });
+
+        it('all category values are valid', () => {
+            const validCategories = CATEGORIES.filter(c => c !== 'all');
+            for (const example of galleryExamples) {
+                expect(validCategories, `${example.id} has invalid category: ${example.category}`).toContain(example.category);
+            }
+        });
+
+        it('all examples have 1-5 tags', () => {
+            for (const example of galleryExamples) {
+                expect(example.tags.length, `${example.id} has ${example.tags.length} tags`).toBeGreaterThanOrEqual(1);
+                expect(example.tags.length, `${example.id} has ${example.tags.length} tags`).toBeLessThanOrEqual(5);
+            }
+        });
+
+        it('all source URLs are valid awesome-compose links', () => {
+            for (const example of galleryExamples) {
+                expect(example.source).toMatch(/^https:\/\/github\.com\/docker\/awesome-compose/);
+            }
+        });
+    });
+
+    describe('filterExamples', () => {
+        it('returns all examples when category is "all"', () => {
+            const result = filterExamples(galleryExamples, 'all');
+            expect(result).toEqual(galleryExamples);
+        });
+
+        it('returns correct subset for each category', () => {
+            const categories = ['web', 'backend', 'fullstack', 'monitoring', 'database'];
+            for (const cat of categories) {
+                const result = filterExamples(galleryExamples, cat);
+                for (const item of result) {
+                    expect(item.category).toBe(cat);
+                }
+            }
+        });
+
+        it('returns empty array for non-existent category', () => {
+            const result = filterExamples(galleryExamples, 'nonexistent');
+            expect(result).toEqual([]);
+        });
+
+        it('does not mutate the original array', () => {
+            const original = [...galleryExamples];
+            filterExamples(galleryExamples, 'fullstack');
+            expect(galleryExamples).toEqual(original);
+        });
+
+        it('preserves order within filtered results', () => {
+            const fullstack = filterExamples(galleryExamples, 'fullstack');
+            const fullstackFromOriginal = galleryExamples.filter(e => e.category === 'fullstack');
+            expect(fullstack).toEqual(fullstackFromOriginal);
+        });
+
+        it('sum of all category counts equals total', () => {
+            const categories = ['web', 'backend', 'fullstack', 'monitoring', 'database'];
+            let sum = 0;
+            for (const cat of categories) {
+                sum += filterExamples(galleryExamples, cat).length;
+            }
+            expect(sum).toBe(galleryExamples.length);
+        });
+    });
+
+    describe('getExamplesGallery', () => {
+        it('returns all examples', () => {
+            const result = getExamplesGallery();
+            expect(result.length).toBe(galleryExamples.length);
+        });
+
+        it('returns sorted by category then name', () => {
+            const result = getExamplesGallery();
+            for (let i = 1; i < result.length; i++) {
+                const prev = result[i - 1];
+                const curr = result[i];
+                const catCompare = prev.category.localeCompare(curr.category);
+                if (catCompare === 0) {
+                    expect(prev.name.localeCompare(curr.name)).toBeLessThanOrEqual(0);
+                } else {
+                    expect(catCompare).toBeLessThan(0);
+                }
+            }
+        });
+
+        it('does not mutate the original array', () => {
+            const original = [...galleryExamples];
+            getExamplesGallery();
+            expect(galleryExamples).toEqual(original);
+        });
+    });
+});

--- a/src/hooks/useCompose.jsx
+++ b/src/hooks/useCompose.jsx
@@ -6,6 +6,7 @@ import { validateState } from '../utils/validation';
 import { generateSuggestions } from '../utils/suggestions';
 import { useHistoryReducer } from './useHistory';
 import { composeReducer, initialState } from './composeReducer';
+import { enrichComposeState } from '../utils/dockerfileEnricher.js';
 
 // Context
 const ComposeContext = createContext(null);
@@ -95,7 +96,7 @@ export function ComposeProvider({ children }) {
     const loadFiles = useCallback(async (content, files = [], overrides = {}) => {
         try {
             // Build fileMap from uploaded files
-            const fileMap = {};
+            const fileMap = overrides.fileMap ? { ...overrides.fileMap } : {};
             const effectiveFiles = files.length > 0 ? files : (lastFilesRef.current || []);
             const envFromFiles = {};
             if (effectiveFiles && effectiveFiles.length > 0) {
@@ -139,7 +140,18 @@ export function ComposeProvider({ children }) {
 
                 // Update state with parsed compose
                 if (result.compose) {
-                    dispatch({ type: 'SET_STATE', payload: result.compose });
+                    // Enrich compose state with Dockerfile metadata
+                    let enrichedState = result.compose;
+                    try {
+                        enrichedState = await enrichComposeState(result.compose, {
+                            fileMap,
+                            exampleDir: overrides.exampleDir || null,
+                            timeout: 5000
+                        });
+                    } catch {
+                        // Enrichment failure is non-fatal — use original state
+                    }
+                    dispatch({ type: 'SET_STATE', payload: enrichedState });
                 }
 
                 // Update parser metadata

--- a/src/hooks/useFileImport.js
+++ b/src/hooks/useFileImport.js
@@ -74,10 +74,11 @@ export function useFileImport(loadFiles, setActiveView, isMobile, onError) {
      * Handles file import from drag-and-drop or file input
      * @param {string} content - Primary YAML content
      * @param {Array} files - Array of files to import
+     * @param {Object} overrides - Optional overrides to pass to loadFiles
      */
-    const handleImport = async (content, files = []) => {
+    const handleImport = async (content, files = [], overrides = {}) => {
         try {
-            const result = await loadFiles(content, files);
+            const result = await loadFiles(content, files, overrides);
             if (!result.success) {
                 showError('Invalid YAML: ' + (result.error || 'Unknown error'));
                 return;

--- a/src/utils/dockerfileEnricher.integration.test.js
+++ b/src/utils/dockerfileEnricher.integration.test.js
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { enrichComposeState } from './dockerfileEnricher.js';
+import { generateGraphviz } from './graphviz.js';
+import { clearDockerfileCache } from './dockerfileFetcher.js';
+
+/**
+ * Integration tests for the Dockerfile enrichment pipeline.
+ * Tests the full flow: compose state → enrichment → graphviz output.
+ * Validates: Requirements 4.1, 4.4, 5.1
+ */
+
+describe('Dockerfile Enrichment Integration', () => {
+    beforeEach(() => {
+        clearDockerfileCache();
+    });
+
+    it('enriches services with build directives using fileMap Dockerfiles', async () => {
+        const composeState = {
+            services: {
+                backend: {
+                    build: './backend'
+                },
+                frontend: {
+                    build: { context: './frontend', dockerfile: 'Dockerfile' }
+                },
+                db: {
+                    image: 'postgres:15'
+                }
+            }
+        };
+
+        const fileMap = {
+            'backend/Dockerfile': 'FROM node:18-alpine\nEXPOSE 3000\n',
+            'frontend/Dockerfile': 'FROM nginx:latest\nEXPOSE 80\nEXPOSE 443\n'
+        };
+
+        const enriched = await enrichComposeState(composeState, {
+            fileMap,
+            exampleDir: null,
+            timeout: 5000
+        });
+
+        // Backend should have resolved image and ports
+        expect(enriched.services.backend._resolvedImage).toBe('node:18-alpine');
+        expect(enriched.services.backend._resolvedPorts).toEqual([
+            { port: 3000, protocol: 'tcp' }
+        ]);
+
+        // Frontend should have resolved image and ports
+        expect(enriched.services.frontend._resolvedImage).toBe('nginx:latest');
+        expect(enriched.services.frontend._resolvedPorts).toEqual([
+            { port: 80, protocol: 'tcp' },
+            { port: 443, protocol: 'tcp' }
+        ]);
+
+        // DB with explicit image should NOT be enriched
+        expect(enriched.services.db._resolvedImage).toBeUndefined();
+        expect(enriched.services.db._resolvedPorts).toBeUndefined();
+    });
+
+    it('enriched state produces DOT output with resolved image names', async () => {
+        const composeState = {
+            services: {
+                api: {
+                    build: './api'
+                },
+                worker: {
+                    build: './worker'
+                }
+            }
+        };
+
+        const fileMap = {
+            'api/Dockerfile': 'FROM python:3.11-slim\nEXPOSE 8000\n',
+            'worker/Dockerfile': 'FROM golang:1.21\n'
+        };
+
+        const enriched = await enrichComposeState(composeState, {
+            fileMap,
+            exampleDir: null,
+            timeout: 5000
+        });
+
+        const dot = generateGraphviz(enriched);
+
+        // DOT output should contain resolved image names (without tags)
+        expect(dot).toContain('<python>');
+        expect(dot).toContain('<golang>');
+
+        // Should contain port from EXPOSE
+        expect(dot).toContain('label="8000"');
+    });
+
+    it('services with explicit image are not enriched even with matching Dockerfile', async () => {
+        const composeState = {
+            services: {
+                app: {
+                    build: './app',
+                    image: 'myregistry/myapp:v2'
+                }
+            }
+        };
+
+        const fileMap = {
+            'app/Dockerfile': 'FROM node:20\nEXPOSE 4000\n'
+        };
+
+        const enriched = await enrichComposeState(composeState, {
+            fileMap,
+            exampleDir: null,
+            timeout: 5000
+        });
+
+        // Should NOT be enriched because explicit image exists
+        expect(enriched.services.app._resolvedImage).toBeUndefined();
+        expect(enriched.services.app.image).toBe('myregistry/myapp:v2');
+    });
+
+    it('services with explicit ports do not get _resolvedPorts', async () => {
+        const composeState = {
+            services: {
+                web: {
+                    build: './web',
+                    ports: ['9000:9000']
+                }
+            }
+        };
+
+        const fileMap = {
+            'web/Dockerfile': 'FROM node:18\nEXPOSE 3000\n'
+        };
+
+        const enriched = await enrichComposeState(composeState, {
+            fileMap,
+            exampleDir: null,
+            timeout: 5000
+        });
+
+        // Should have _resolvedImage but NOT _resolvedPorts (explicit ports exist)
+        expect(enriched.services.web._resolvedImage).toBe('node:18');
+        expect(enriched.services.web._resolvedPorts).toBeUndefined();
+    });
+
+    it('enrichment with missing Dockerfile leaves service unchanged', async () => {
+        const composeState = {
+            services: {
+                app: {
+                    build: './app'
+                }
+            }
+        };
+
+        const fileMap = {};
+
+        const enriched = await enrichComposeState(composeState, {
+            fileMap,
+            exampleDir: null,
+            timeout: 5000
+        });
+
+        // No Dockerfile available — service should remain unchanged
+        expect(enriched.services.app._resolvedImage).toBeUndefined();
+        expect(enriched.services.app._resolvedPorts).toBeUndefined();
+        expect(enriched.services.app.build).toBe('./app');
+    });
+
+    it('multi-stage Dockerfile with target resolves correct image', async () => {
+        const composeState = {
+            services: {
+                app: {
+                    build: {
+                        context: './app',
+                        target: 'production'
+                    }
+                }
+            }
+        };
+
+        const fileMap = {
+            'app/Dockerfile': [
+                'FROM node:18 AS builder',
+                'RUN npm ci',
+                '',
+                'FROM nginx:alpine AS production',
+                'COPY --from=builder /app/dist /usr/share/nginx/html',
+                'EXPOSE 80'
+            ].join('\n')
+        };
+
+        const enriched = await enrichComposeState(composeState, {
+            fileMap,
+            exampleDir: null,
+            timeout: 5000
+        });
+
+        // Should resolve to the target stage's FROM image
+        expect(enriched.services.app._resolvedImage).toBe('nginx:alpine');
+        expect(enriched.services.app._resolvedPorts).toEqual([
+            { port: 80, protocol: 'tcp' }
+        ]);
+    });
+});

--- a/src/utils/dockerfileEnricher.js
+++ b/src/utils/dockerfileEnricher.js
@@ -1,0 +1,119 @@
+/**
+ * Dockerfile enricher module.
+ * Orchestrates enrichment of compose state with Dockerfile metadata
+ * for all services that have build directives.
+ *
+ * @module dockerfileEnricher
+ */
+
+import { fetchDockerfile } from './dockerfileFetcher.js';
+import { parseDockerfile } from './dockerfileParser.js';
+
+/**
+ * @typedef {Object} EnrichOptions
+ * @property {Object} fileMap - Local file map from folder upload
+ * @property {string|null} exampleDir - Remote example directory name (for GitHub fetch)
+ * @property {number} timeout - Per-service timeout in ms (default: 5000)
+ */
+
+/**
+ * Default per-service timeout in milliseconds.
+ */
+const DEFAULT_TIMEOUT = 5000;
+
+/**
+ * Enrich a single service with Dockerfile metadata.
+ * Resolves the build context, fetches the Dockerfile, parses it,
+ * and attaches _resolvedImage and _resolvedPorts fields.
+ *
+ * @param {Object} service - The service object from compose state
+ * @param {EnrichOptions} options - Fetch options
+ * @returns {Promise<void>}
+ */
+async function enrichService(service, options) {
+  const build = service.build;
+
+  // Resolve context path and dockerfile name from build directive
+  let contextPath;
+  let dockerfileName = 'Dockerfile';
+  let target = null;
+
+  if (typeof build === 'string') {
+    contextPath = build;
+  } else if (build && typeof build === 'object') {
+    contextPath = build.context;
+    if (build.dockerfile) {
+      dockerfileName = build.dockerfile;
+    }
+    if (build.target) {
+      target = build.target;
+    }
+  } else {
+    return;
+  }
+
+  if (!contextPath) return;
+
+  const content = await fetchDockerfile(contextPath, dockerfileName, options);
+  if (!content) return;
+
+  const metadata = parseDockerfile(content, target);
+  if (!metadata) return;
+
+  if (metadata.baseImage) {
+    service._resolvedImage = metadata.baseImage;
+  }
+
+  if (metadata.exposedPorts && metadata.exposedPorts.length > 0 && !service.ports) {
+    service._resolvedPorts = metadata.exposedPorts;
+  }
+}
+
+/**
+ * Enrich compose state with Dockerfile metadata for all services with build directives.
+ * Mutates the state object in place (adds _resolvedImage, _resolvedPorts fields).
+ * Services that already have an explicit `image` field are skipped.
+ * Uses Promise.allSettled so one service failure doesn't block others.
+ * Each service enrichment is wrapped in a Promise.race with a timeout.
+ *
+ * @param {Object} state - Parsed compose state (services, networks, etc.)
+ * @param {EnrichOptions} [options={}] - Enrichment options
+ * @returns {Promise<Object>} The enriched state (same reference, mutated)
+ */
+export async function enrichComposeState(state, options = {}) {
+  try {
+    if (!state || !state.services || typeof state.services !== 'object') {
+      return state;
+    }
+
+    const timeout = options.timeout || DEFAULT_TIMEOUT;
+    const serviceEntries = Object.entries(state.services);
+
+    const promises = serviceEntries.map(([, service]) => {
+      // Skip services without a build directive
+      if (!service.build) {
+        return Promise.resolve();
+      }
+
+      // Skip services that already have an explicit image field
+      if (service.image) {
+        return Promise.resolve();
+      }
+
+      // Wrap enrichment in Promise.race with timeout
+      const enrichmentPromise = enrichService(service, options);
+      const timeoutPromise = new Promise((resolve) => {
+        setTimeout(resolve, timeout);
+      });
+
+      return Promise.race([enrichmentPromise, timeoutPromise]);
+    });
+
+    await Promise.allSettled(promises);
+
+    return state;
+  } catch {
+    // Never throw — return state unchanged on any unexpected error
+    return state;
+  }
+}

--- a/src/utils/dockerfileEnricher.property.test.js
+++ b/src/utils/dockerfileEnricher.property.test.js
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fc from 'fast-check';
+import { enrichComposeState } from './dockerfileEnricher';
+
+vi.mock('./dockerfileFetcher.js', () => ({
+  fetchDockerfile: vi.fn(),
+}));
+
+vi.mock('./dockerfileParser.js', () => ({
+  parseDockerfile: vi.fn(),
+}));
+
+import { fetchDockerfile } from './dockerfileFetcher.js';
+import { parseDockerfile } from './dockerfileParser.js';
+
+/**
+ * Property-based tests for the Dockerfile enricher.
+ * Uses fast-check to verify correctness properties across many random inputs.
+ *
+ * Validates: Requirements 4.1, 4.2, 4.3, 4.5
+ */
+describe('Dockerfile Enricher - Property-Based Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Generators ---
+
+  /** Generate a valid Docker image name */
+  const arbImageName = () =>
+    fc.tuple(
+      fc.stringMatching(/^[a-z][a-z0-9]{0,11}$/),
+      fc.option(
+        fc.stringMatching(/^[a-z0-9][a-z0-9.-]{0,7}$/),
+        { nil: undefined }
+      )
+    ).map(([name, tag]) => tag ? `${name}:${tag}` : name);
+
+  /** Generate a valid port number */
+  const arbPort = () => fc.integer({ min: 1, max: 65535 });
+
+  /** Generate exposed ports array */
+  const arbExposedPorts = () =>
+    fc.array(
+      fc.tuple(arbPort(), fc.constantFrom('tcp', 'udp')).map(([port, protocol]) => ({
+        port,
+        protocol,
+      })),
+      { minLength: 0, maxLength: 5 }
+    );
+
+  /** Generate a build context path */
+  const arbContextPath = () =>
+    fc.constantFrom('./backend', './frontend', './api', './worker', 'services/web', './app');
+
+  /** Generate a build directive (string or object) */
+  const arbBuildDirective = () =>
+    fc.oneof(
+      arbContextPath(),
+      fc.record({
+        context: arbContextPath(),
+        dockerfile: fc.option(fc.constantFrom('Dockerfile', 'Dockerfile.prod', 'Dockerfile.dev'), { nil: undefined }),
+        target: fc.option(fc.constantFrom('builder', 'production', 'dev'), { nil: undefined }),
+      }).map(({ context, dockerfile, target }) => {
+        const obj = { context };
+        if (dockerfile) obj.dockerfile = dockerfile;
+        if (target) obj.target = target;
+        return obj;
+      })
+    );
+
+  /** Generate a service name */
+  const arbServiceName = () =>
+    fc.stringMatching(/^[a-z][a-z0-9_]{0,9}$/);
+
+  /**
+   * Property 4: Enrichment Field Assignment
+   *
+   * For any compose state with build directives and available Dockerfiles,
+   * _resolvedImage is set only when no explicit image exists,
+   * _resolvedPorts only when no explicit ports exist.
+   *
+   * Validates: Requirements 4.1, 4.2, 4.3
+   */
+  describe('Property 4: Enrichment Field Assignment', () => {
+    it('_resolvedImage is set only when service has no explicit image field', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.tuple(
+            arbServiceName(),
+            arbBuildDirective(),
+            arbImageName(),
+            fc.boolean() // whether service has explicit image
+          ),
+          async ([serviceName, build, resolvedImage, hasExplicitImage]) => {
+            vi.clearAllMocks();
+
+            fetchDockerfile.mockResolvedValue('FROM something\n');
+            parseDockerfile.mockReturnValue({
+              baseImage: resolvedImage,
+              exposedPorts: [],
+            });
+
+            const service = { build };
+            if (hasExplicitImage) {
+              service.image = 'explicit:latest';
+            }
+
+            const state = { services: { [serviceName]: service } };
+            await enrichComposeState(state);
+
+            if (hasExplicitImage) {
+              // Should NOT set _resolvedImage when explicit image exists
+              expect(state.services[serviceName]._resolvedImage).toBeUndefined();
+            } else {
+              // Should set _resolvedImage when no explicit image
+              expect(state.services[serviceName]._resolvedImage).toBe(resolvedImage);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('_resolvedPorts is set only when service has no explicit ports field', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.tuple(
+            arbServiceName(),
+            arbBuildDirective(),
+            arbExposedPorts().filter(ports => ports.length > 0),
+            fc.boolean() // whether service has explicit ports
+          ),
+          async ([serviceName, build, exposedPorts, hasExplicitPorts]) => {
+            vi.clearAllMocks();
+
+            fetchDockerfile.mockResolvedValue('FROM something\nEXPOSE 3000\n');
+            parseDockerfile.mockReturnValue({
+              baseImage: 'node:18',
+              exposedPorts,
+            });
+
+            const service = { build };
+            if (hasExplicitPorts) {
+              service.ports = ['3000:3000'];
+            }
+
+            const state = { services: { [serviceName]: service } };
+            await enrichComposeState(state);
+
+            if (hasExplicitPorts) {
+              // Should NOT set _resolvedPorts when explicit ports exist
+              expect(state.services[serviceName]._resolvedPorts).toBeUndefined();
+            } else {
+              // Should set _resolvedPorts when no explicit ports
+              expect(state.services[serviceName]._resolvedPorts).toEqual(exposedPorts);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 5: Enrichment Failure Isolation
+   *
+   * For any service where fetching/parsing fails (returns null),
+   * the service object remains unchanged with no new fields added.
+   *
+   * Validates: Requirements 4.5
+   */
+  describe('Property 5: Enrichment Failure Isolation', () => {
+    it('no _resolvedImage or _resolvedPorts fields added when fetch fails', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.tuple(
+            arbServiceName(),
+            arbBuildDirective(),
+            // Generate arbitrary pre-existing fields
+            fc.record({
+              environment: fc.option(
+                fc.dictionary(
+                  fc.stringMatching(/^[A-Z_]{1,8}$/),
+                  fc.string({ minLength: 1, maxLength: 10 })
+                ),
+                { nil: undefined }
+              ),
+              volumes: fc.option(
+                fc.array(fc.string({ minLength: 1, maxLength: 20 }), { minLength: 0, maxLength: 3 }),
+                { nil: undefined }
+              ),
+            })
+          ),
+          async ([serviceName, build, extraFields]) => {
+            vi.clearAllMocks();
+
+            // Simulate fetch failure
+            fetchDockerfile.mockResolvedValue(null);
+
+            const service = { build };
+            if (extraFields.environment) service.environment = extraFields.environment;
+            if (extraFields.volumes) service.volumes = extraFields.volumes;
+
+            // Snapshot pre-existing keys
+            const originalKeys = Object.keys(service).sort();
+            const originalValues = JSON.parse(JSON.stringify(service));
+
+            const state = { services: { [serviceName]: service } };
+            await enrichComposeState(state);
+
+            // No new enrichment fields should be added
+            expect(state.services[serviceName]._resolvedImage).toBeUndefined();
+            expect(state.services[serviceName]._resolvedPorts).toBeUndefined();
+
+            // All pre-existing fields should remain unchanged
+            for (const key of originalKeys) {
+              expect(JSON.stringify(state.services[serviceName][key]))
+                .toBe(JSON.stringify(originalValues[key]));
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('no _resolvedImage or _resolvedPorts fields added when parse returns null baseImage', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.tuple(
+            arbServiceName(),
+            arbBuildDirective()
+          ),
+          async ([serviceName, build]) => {
+            vi.clearAllMocks();
+
+            fetchDockerfile.mockResolvedValue('# empty dockerfile\n');
+            parseDockerfile.mockReturnValue({
+              baseImage: null,
+              exposedPorts: [],
+            });
+
+            const service = { build };
+            const state = { services: { [serviceName]: service } };
+            await enrichComposeState(state);
+
+            expect(state.services[serviceName]._resolvedImage).toBeUndefined();
+            expect(state.services[serviceName]._resolvedPorts).toBeUndefined();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/src/utils/dockerfileEnricher.test.js
+++ b/src/utils/dockerfileEnricher.test.js
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { enrichComposeState } from './dockerfileEnricher';
+
+vi.mock('./dockerfileFetcher.js', () => ({
+  fetchDockerfile: vi.fn(),
+}));
+
+vi.mock('./dockerfileParser.js', () => ({
+  parseDockerfile: vi.fn(),
+}));
+
+import { fetchDockerfile } from './dockerfileFetcher.js';
+import { parseDockerfile } from './dockerfileParser.js';
+
+describe('dockerfileEnricher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('enrichComposeState', () => {
+    it('sets _resolvedImage when service has build + no image', async () => {
+      fetchDockerfile.mockResolvedValue('FROM node:18-alpine\n');
+      parseDockerfile.mockReturnValue({
+        baseImage: 'node:18-alpine',
+        exposedPorts: [],
+      });
+
+      const state = {
+        services: {
+          web: { build: './frontend' },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(result.services.web._resolvedImage).toBe('node:18-alpine');
+      expect(fetchDockerfile).toHaveBeenCalledWith('./frontend', 'Dockerfile', expect.any(Object));
+      expect(parseDockerfile).toHaveBeenCalledWith('FROM node:18-alpine\n', null);
+    });
+
+    it('does NOT set _resolvedImage when service has explicit image', async () => {
+      const state = {
+        services: {
+          web: { build: './frontend', image: 'myapp:latest' },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(result.services.web._resolvedImage).toBeUndefined();
+      expect(fetchDockerfile).not.toHaveBeenCalled();
+    });
+
+    it('sets _resolvedPorts when EXPOSE found and no explicit ports', async () => {
+      fetchDockerfile.mockResolvedValue('FROM node:18\nEXPOSE 3000 8080\n');
+      parseDockerfile.mockReturnValue({
+        baseImage: 'node:18',
+        exposedPorts: [
+          { port: 3000, protocol: 'tcp' },
+          { port: 8080, protocol: 'tcp' },
+        ],
+      });
+
+      const state = {
+        services: {
+          api: { build: './backend' },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(result.services.api._resolvedPorts).toEqual([
+        { port: 3000, protocol: 'tcp' },
+        { port: 8080, protocol: 'tcp' },
+      ]);
+    });
+
+    it('does NOT set _resolvedPorts when service has explicit ports', async () => {
+      fetchDockerfile.mockResolvedValue('FROM node:18\nEXPOSE 3000\n');
+      parseDockerfile.mockReturnValue({
+        baseImage: 'node:18',
+        exposedPorts: [{ port: 3000, protocol: 'tcp' }],
+      });
+
+      const state = {
+        services: {
+          api: { build: './backend', ports: ['3000:3000'] },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(result.services.api._resolvedPorts).toBeUndefined();
+      expect(result.services.api._resolvedImage).toBe('node:18');
+    });
+
+    it('leaves service unchanged when fetch returns null', async () => {
+      fetchDockerfile.mockResolvedValue(null);
+
+      const state = {
+        services: {
+          api: { build: './backend', environment: { NODE_ENV: 'production' } },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(result.services.api._resolvedImage).toBeUndefined();
+      expect(result.services.api._resolvedPorts).toBeUndefined();
+      expect(result.services.api.environment).toEqual({ NODE_ENV: 'production' });
+    });
+
+    it('handles multiple services with partial failure', async () => {
+      fetchDockerfile
+        .mockResolvedValueOnce('FROM node:18\n')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('FROM python:3.11\n');
+
+      parseDockerfile
+        .mockReturnValueOnce({ baseImage: 'node:18', exposedPorts: [] })
+        .mockReturnValueOnce({ baseImage: 'python:3.11', exposedPorts: [] });
+
+      const state = {
+        services: {
+          frontend: { build: './frontend' },
+          backend: { build: './backend' },
+          worker: { build: './worker' },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(result.services.frontend._resolvedImage).toBe('node:18');
+      expect(result.services.backend._resolvedImage).toBeUndefined();
+      expect(result.services.worker._resolvedImage).toBe('python:3.11');
+    });
+
+    it('resolves shorthand build string correctly', async () => {
+      fetchDockerfile.mockResolvedValue('FROM golang:1.21\n');
+      parseDockerfile.mockReturnValue({
+        baseImage: 'golang:1.21',
+        exposedPorts: [],
+      });
+
+      const state = {
+        services: {
+          api: { build: './backend' },
+        },
+      };
+
+      await enrichComposeState(state);
+
+      expect(fetchDockerfile).toHaveBeenCalledWith('./backend', 'Dockerfile', expect.any(Object));
+    });
+
+    it('resolves build object with context and dockerfile', async () => {
+      fetchDockerfile.mockResolvedValue('FROM node:20\n');
+      parseDockerfile.mockReturnValue({
+        baseImage: 'node:20',
+        exposedPorts: [],
+      });
+
+      const state = {
+        services: {
+          web: {
+            build: {
+              context: './frontend',
+              dockerfile: 'Dockerfile.prod',
+              target: 'production',
+            },
+          },
+        },
+      };
+
+      await enrichComposeState(state);
+
+      expect(fetchDockerfile).toHaveBeenCalledWith(
+        './frontend',
+        'Dockerfile.prod',
+        expect.any(Object)
+      );
+      expect(parseDockerfile).toHaveBeenCalledWith('FROM node:20\n', 'production');
+    });
+
+    it('handles timeout by leaving service unchanged', async () => {
+      // Simulate a slow fetch that takes longer than the timeout
+      fetchDockerfile.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve('FROM slow:1.0\n'), 200))
+      );
+
+      const state = {
+        services: {
+          slow: { build: './slow-service' },
+        },
+      };
+
+      // Use a very short timeout
+      const result = await enrichComposeState(state, { timeout: 50 });
+
+      // Service should remain unchanged because timeout fires first
+      expect(result.services.slow._resolvedImage).toBeUndefined();
+    });
+
+    it('skips services with no build directive', async () => {
+      const state = {
+        services: {
+          db: { image: 'postgres:15' },
+          cache: { image: 'redis:7' },
+        },
+      };
+
+      const result = await enrichComposeState(state);
+
+      expect(fetchDockerfile).not.toHaveBeenCalled();
+      expect(result.services.db._resolvedImage).toBeUndefined();
+      expect(result.services.cache._resolvedImage).toBeUndefined();
+    });
+
+    it('returns state unchanged when state has no services', async () => {
+      const state = { services: {} };
+      const result = await enrichComposeState(state);
+      expect(result).toBe(state);
+    });
+
+    it('returns state unchanged when state is null or invalid', async () => {
+      const result1 = await enrichComposeState(null);
+      expect(result1).toBeNull();
+
+      const result2 = await enrichComposeState({});
+      expect(result2).toEqual({});
+    });
+  });
+});

--- a/src/utils/dockerfileFetcher.js
+++ b/src/utils/dockerfileFetcher.js
@@ -1,0 +1,157 @@
+/**
+ * Dockerfile fetcher module.
+ * Fetches Dockerfile content from local file maps or remote GitHub raw URLs,
+ * with session-scoped caching and configurable timeouts.
+ *
+ * @module dockerfileFetcher
+ */
+
+/**
+ * @typedef {Object} FetchOptions
+ * @property {Object} fileMap - Local file map from folder upload
+ * @property {string|null} exampleDir - Remote example directory name (e.g., "nginx-flask-mysql")
+ * @property {number} timeout - Per-fetch timeout in ms (default: 5000)
+ */
+
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/docker/awesome-compose/master';
+
+/** Session-scoped cache keyed by resolved path */
+const _cache = new Map();
+
+/**
+ * Normalize a context path by stripping leading "./" prefix.
+ *
+ * @param {string} contextPath - The build context path (e.g., "./backend" or "backend")
+ * @returns {string} Normalized path without leading "./"
+ */
+function normalizePath(contextPath) {
+  if (!contextPath) return '';
+  let normalized = contextPath;
+  if (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+  // Also strip trailing slash
+  if (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+/**
+ * Construct the full Dockerfile path from context and filename.
+ *
+ * @param {string} contextPath - Build context path (e.g., "./backend")
+ * @param {string} dockerfileName - Dockerfile name (default: "Dockerfile")
+ * @returns {string} Full path like "backend/Dockerfile"
+ */
+function buildFullPath(contextPath, dockerfileName) {
+  const normalized = normalizePath(contextPath);
+  if (!normalized || normalized === '.') {
+    return dockerfileName;
+  }
+  return `${normalized}/${dockerfileName}`;
+}
+
+/**
+ * Attempt to resolve Dockerfile content from a local fileMap.
+ * Tries multiple path variations to handle different fileMap key formats.
+ *
+ * @param {string} fullPath - The normalized full path (e.g., "backend/Dockerfile")
+ * @param {Object} fileMap - Local file map
+ * @param {string|null} exampleDir - Example directory prefix to try
+ * @returns {string|null} File content or null if not found
+ */
+function resolveFromFileMap(fullPath, fileMap, exampleDir) {
+  if (!fileMap || typeof fileMap !== 'object') return null;
+
+  // Try direct path
+  if (fileMap[fullPath] !== undefined) {
+    return fileMap[fullPath];
+  }
+
+  // Try with project prefix (exampleDir)
+  if (exampleDir) {
+    const withPrefix = `${exampleDir}/${fullPath}`;
+    if (fileMap[withPrefix] !== undefined) {
+      return fileMap[withPrefix];
+    }
+  }
+
+  // Try with "./" prefix
+  const withDotSlash = `./${fullPath}`;
+  if (fileMap[withDotSlash] !== undefined) {
+    return fileMap[withDotSlash];
+  }
+
+  return null;
+}
+
+/**
+ * Fetch Dockerfile content for a service's build context.
+ * Checks local fileMap first, then falls back to GitHub raw URL.
+ * Returns null on any failure (network, 404, timeout) — never throws.
+ *
+ * @param {string} contextPath - Build context path (e.g., "./backend")
+ * @param {string} [dockerfileName="Dockerfile"] - Dockerfile name
+ * @param {FetchOptions} [options={}] - Fetch options
+ * @returns {Promise<string|null>} Dockerfile content or null
+ */
+export async function fetchDockerfile(contextPath, dockerfileName = 'Dockerfile', options = {}) {
+  try {
+    const { fileMap = null, exampleDir = null, timeout = 5000 } = options;
+    const fullPath = buildFullPath(contextPath, dockerfileName);
+
+    // Check cache first
+    if (_cache.has(fullPath)) {
+      return _cache.get(fullPath);
+    }
+
+    // Try local fileMap first
+    const localContent = resolveFromFileMap(fullPath, fileMap, exampleDir);
+    if (localContent !== null) {
+      _cache.set(fullPath, localContent);
+      return localContent;
+    }
+
+    // If no exampleDir, we can't construct a remote URL
+    if (!exampleDir) {
+      _cache.set(fullPath, null);
+      return null;
+    }
+
+    // Construct GitHub raw URL
+    const url = `${GITHUB_RAW_BASE}/${exampleDir}/${fullPath}`;
+
+    // Fetch with AbortController timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        _cache.set(fullPath, null);
+        return null;
+      }
+
+      const content = await response.text();
+      _cache.set(fullPath, content);
+      return content;
+    } catch {
+      clearTimeout(timeoutId);
+      _cache.set(fullPath, null);
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clear the Dockerfile content cache.
+ * Useful for testing or when loading a new project.
+ */
+export function clearDockerfileCache() {
+  _cache.clear();
+}

--- a/src/utils/dockerfileFetcher.property.test.js
+++ b/src/utils/dockerfileFetcher.property.test.js
@@ -1,0 +1,160 @@
+/* global global */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fc from 'fast-check';
+import { fetchDockerfile, clearDockerfileCache } from './dockerfileFetcher';
+
+describe('dockerfileFetcher - Property Tests', () => {
+  beforeEach(() => {
+    clearDockerfileCache();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Property 1: Dockerfile Path Resolution
+   *
+   * For any build context path (with or without "./" prefix) and any dockerfile name,
+   * the fetcher constructs a URL containing the normalized path.
+   *
+   * **Validates: Requirements 1.1, 1.2, 1.3, 1.5, 6.1, 6.2**
+   */
+  describe('Property 1: Dockerfile Path Resolution', () => {
+    it('constructs a URL combining exampleDir, normalized context, and dockerfile name', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          // Generate context paths (with or without ./ prefix)
+          fc.oneof(
+            fc.stringMatching(/^[a-z][a-z0-9-]{0,20}$/),
+            fc.stringMatching(/^[a-z][a-z0-9-]{0,20}$/).map(s => `./${s}`)
+          ),
+          // Generate dockerfile names
+          fc.oneof(
+            fc.constant('Dockerfile'),
+            fc.stringMatching(/^Dockerfile\.[a-z]{1,10}$/)
+          ),
+          // Generate example directory names
+          fc.stringMatching(/^[a-z][a-z0-9-]{2,20}$/),
+          async (contextPath, dockerfileName, exampleDir) => {
+            // Clear cache to avoid cross-iteration interference
+            clearDockerfileCache();
+
+            // Track what URL was called
+            let calledUrl = null;
+            global.fetch = vi.fn().mockImplementation((url) => {
+              calledUrl = url;
+              return Promise.resolve({ ok: false, status: 404 });
+            });
+
+            await fetchDockerfile(contextPath, dockerfileName, { exampleDir });
+
+            // The URL should contain the exampleDir
+            expect(calledUrl).toContain(exampleDir);
+
+            // The URL should contain the normalized context (without ./)
+            const normalizedContext = contextPath.startsWith('./')
+              ? contextPath.slice(2)
+              : contextPath;
+            expect(calledUrl).toContain(normalizedContext);
+
+            // The URL should contain the dockerfile name
+            expect(calledUrl).toContain(dockerfileName);
+
+            // The URL should follow the pattern: base/exampleDir/context/dockerfileName
+            const expectedPath = `${exampleDir}/${normalizedContext}/${dockerfileName}`;
+            expect(calledUrl).toContain(expectedPath);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 8: Local FileMap Resolution
+   *
+   * For any fileMap containing a Dockerfile at the matching path,
+   * fetchDockerfile returns that content without making network requests.
+   *
+   * **Validates: Requirements 6.1, 6.2**
+   */
+  describe('Property 8: Local FileMap Resolution', () => {
+    it('returns content from fileMap without network requests for any matching path', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          // Generate context paths (simple directory names)
+          fc.stringMatching(/^[a-z][a-z0-9-]{0,15}$/),
+          // Generate dockerfile names
+          fc.oneof(
+            fc.constant('Dockerfile'),
+            fc.stringMatching(/^Dockerfile\.[a-z]{1,8}$/)
+          ),
+          // Generate file content (non-empty strings)
+          fc.string({ minLength: 5, maxLength: 200 }),
+          async (contextDir, dockerfileName, rawContent) => {
+            // Clear cache to avoid cross-iteration interference
+            clearDockerfileCache();
+
+            const fileContent = `FROM node:18\n${rawContent}`;
+
+            // Build the fileMap with the expected key
+            const fullPath = `${contextDir}/${dockerfileName}`;
+            const fileMap = { [fullPath]: fileContent };
+
+            // Mock fetch to track if it's called
+            global.fetch = vi.fn();
+
+            const result = await fetchDockerfile(contextDir, dockerfileName, { fileMap });
+
+            // Should return the content from fileMap
+            expect(result).toBe(fileContent);
+            // Should NOT make any network requests
+            expect(global.fetch).not.toHaveBeenCalled();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 10: Fetch Cache Idempotence
+   *
+   * For any path fetched once, subsequent calls return identical content
+   * without additional fetch calls.
+   *
+   * **Validates: Requirements 1.5**
+   */
+  describe('Property 10: Fetch Cache Idempotence', () => {
+    it('returns identical content on subsequent calls without additional fetch calls', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          // Generate context paths
+          fc.stringMatching(/^[a-z][a-z0-9-]{0,15}$/),
+          // Generate example directories
+          fc.stringMatching(/^[a-z][a-z0-9-]{2,15}$/),
+          // Generate file content (non-empty)
+          fc.string({ minLength: 5, maxLength: 200 }),
+          async (contextDir, exampleDir, rawContent) => {
+            // Clear cache for each iteration
+            clearDockerfileCache();
+
+            const fileContent = `FROM node:18\n${rawContent}`;
+
+            global.fetch = vi.fn().mockResolvedValue({
+              ok: true,
+              text: () => Promise.resolve(fileContent),
+            });
+
+            const result1 = await fetchDockerfile(contextDir, 'Dockerfile', { exampleDir });
+            const result2 = await fetchDockerfile(contextDir, 'Dockerfile', { exampleDir });
+
+            // Both calls return the same content
+            expect(result1).toBe(result2);
+            // Fetch was only called once
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/src/utils/dockerfileFetcher.test.js
+++ b/src/utils/dockerfileFetcher.test.js
@@ -1,0 +1,259 @@
+/* global global */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchDockerfile, clearDockerfileCache } from './dockerfileFetcher';
+
+describe('dockerfileFetcher', () => {
+  beforeEach(() => {
+    clearDockerfileCache();
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchDockerfile - remote fetch', () => {
+    it('returns content on successful remote fetch', async () => {
+      const dockerfileContent = 'FROM node:18-alpine\nEXPOSE 3000\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'nginx-flask-mysql',
+      });
+
+      expect(result).toBe(dockerfileContent);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/docker/awesome-compose/master/nginx-flask-mysql/backend/Dockerfile',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it('returns null on 404 response without throwing', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'nginx-flask-mysql',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on network error without throwing', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'nginx-flask-mysql',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on timeout without throwing', async () => {
+      // Simulate an abort error (what happens when AbortController fires)
+      global.fetch = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'nginx-flask-mysql',
+        timeout: 100,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('uses default dockerfileName "Dockerfile"', async () => {
+      const dockerfileContent = 'FROM python:3.11\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      const result = await fetchDockerfile('./api', undefined, {
+        exampleDir: 'flask-redis',
+      });
+
+      expect(result).toBe(dockerfileContent);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/docker/awesome-compose/master/flask-redis/api/Dockerfile',
+        expect.any(Object)
+      );
+    });
+
+    it('uses custom dockerfileName when specified', async () => {
+      const dockerfileContent = 'FROM node:20\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      const result = await fetchDockerfile('./frontend', 'Dockerfile.prod', {
+        exampleDir: 'react-express-mongodb',
+      });
+
+      expect(result).toBe(dockerfileContent);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/docker/awesome-compose/master/react-express-mongodb/frontend/Dockerfile.prod',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('fetchDockerfile - local fileMap', () => {
+    it('returns content from fileMap without making network calls', async () => {
+      global.fetch = vi.fn();
+      const fileMap = {
+        'backend/Dockerfile': 'FROM golang:1.21\nEXPOSE 8080\n',
+      };
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        fileMap,
+      });
+
+      expect(result).toBe('FROM golang:1.21\nEXPOSE 8080\n');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('resolves fileMap with project prefix', async () => {
+      global.fetch = vi.fn();
+      const fileMap = {
+        'myproject/backend/Dockerfile': 'FROM rust:1.70\n',
+      };
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        fileMap,
+        exampleDir: 'myproject',
+      });
+
+      expect(result).toBe('FROM rust:1.70\n');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('resolves fileMap with ./ prefix', async () => {
+      global.fetch = vi.fn();
+      const fileMap = {
+        './backend/Dockerfile': 'FROM php:8.2\n',
+      };
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        fileMap,
+      });
+
+      expect(result).toBe('FROM php:8.2\n');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns null when fileMap does not contain the Dockerfile', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+      const fileMap = {
+        'frontend/Dockerfile': 'FROM node:18\n',
+      };
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        fileMap,
+        exampleDir: 'test-project',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchDockerfile - caching', () => {
+    it('returns cached content on second call without fetching again', async () => {
+      const dockerfileContent = 'FROM node:18\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      const result1 = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'test-project',
+      });
+      const result2 = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'test-project',
+      });
+
+      expect(result1).toBe(dockerfileContent);
+      expect(result2).toBe(dockerfileContent);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches null results (negative caching)', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+
+      const result1 = await fetchDockerfile('./missing', 'Dockerfile', {
+        exampleDir: 'test-project',
+      });
+      const result2 = await fetchDockerfile('./missing', 'Dockerfile', {
+        exampleDir: 'test-project',
+      });
+
+      expect(result1).toBeNull();
+      expect(result2).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fetchDockerfile - path resolution', () => {
+    it('resolves shorthand build string path (strips ./)', async () => {
+      const dockerfileContent = 'FROM python:3.11\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {
+        exampleDir: 'flask-redis',
+      });
+
+      expect(result).toBe(dockerfileContent);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/docker/awesome-compose/master/flask-redis/backend/Dockerfile',
+        expect.any(Object)
+      );
+    });
+
+    it('handles context path without ./ prefix', async () => {
+      const dockerfileContent = 'FROM nginx:alpine\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      const result = await fetchDockerfile('frontend', 'Dockerfile', {
+        exampleDir: 'react-nginx',
+      });
+
+      expect(result).toBe(dockerfileContent);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/docker/awesome-compose/master/react-nginx/frontend/Dockerfile',
+        expect.any(Object)
+      );
+    });
+
+    it('returns null when no exampleDir and no fileMap match', async () => {
+      global.fetch = vi.fn();
+
+      const result = await fetchDockerfile('./backend', 'Dockerfile', {});
+
+      expect(result).toBeNull();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearDockerfileCache', () => {
+    it('clears the cache so subsequent calls fetch again', async () => {
+      const dockerfileContent = 'FROM node:18\n';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(dockerfileContent),
+      });
+
+      await fetchDockerfile('./backend', 'Dockerfile', { exampleDir: 'test' });
+      clearDockerfileCache();
+      await fetchDockerfile('./backend', 'Dockerfile', { exampleDir: 'test' });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/utils/dockerfileParser.js
+++ b/src/utils/dockerfileParser.js
@@ -1,0 +1,154 @@
+/**
+ * @typedef {Object} FromInstruction
+ * @property {string} image - The image reference (e.g., "node:18-alpine")
+ * @property {string|null} alias - The AS alias (e.g., "builder"), or null
+ */
+
+/**
+ * @typedef {Object} ExposedPort
+ * @property {number} port - The port number
+ * @property {string} protocol - The protocol ("tcp" or "udp")
+ */
+
+/**
+ * @typedef {Object} DockerfileMetadata
+ * @property {string|null} baseImage - Resolved FROM image (e.g., "node:18-alpine")
+ * @property {Array<ExposedPort>} exposedPorts - EXPOSE ports with protocol
+ */
+
+/**
+ * Parse Dockerfile content to extract FROM and EXPOSE metadata.
+ *
+ * When a target is specified, returns the image from the FROM instruction
+ * whose AS alias matches the target. Otherwise returns the final FROM image.
+ * Never throws — returns safe defaults on any error.
+ *
+ * @param {string} content - Raw Dockerfile content
+ * @param {string|null} [target=null] - Build target stage name (from compose build.target)
+ * @returns {DockerfileMetadata}
+ */
+export function parseDockerfile(content, target = null) {
+  try {
+    if (!content || typeof content !== 'string') {
+      return { baseImage: null, exposedPorts: [] };
+    }
+
+    const fromInstructions = extractFromInstructions(content);
+    const exposedPorts = extractExposeInstructions(content);
+
+    let baseImage = null;
+
+    if (fromInstructions.length > 0) {
+      if (target) {
+        // Find the FROM whose alias matches the target
+        const matched = fromInstructions.find(
+          (f) => f.alias && f.alias.toLowerCase() === target.toLowerCase()
+        );
+        if (matched) {
+          baseImage = matched.image;
+        } else {
+          // Fallback to final FROM if target not found
+          baseImage = fromInstructions[fromInstructions.length - 1].image;
+        }
+      } else {
+        // No target specified — use the final FROM
+        baseImage = fromInstructions[fromInstructions.length - 1].image;
+      }
+    }
+
+    return { baseImage, exposedPorts };
+  } catch {
+    return { baseImage: null, exposedPorts: [] };
+  }
+}
+
+/**
+ * Extract all FROM instructions from Dockerfile content.
+ * Returns array of {image, alias} objects in order of appearance.
+ * Skips comment lines and parser directives.
+ *
+ * @param {string} content - Raw Dockerfile content
+ * @returns {Array<FromInstruction>}
+ */
+export function extractFromInstructions(content) {
+  if (!content || typeof content !== 'string') {
+    return [];
+  }
+
+  const results = [];
+  const lines = content.split('\n');
+
+  // Regex: FROM <image> [AS <alias>]
+  // image can contain letters, digits, /, -, _, ., :, @, $, {, }
+  const fromRegex = /^\s*FROM\s+(\S+)(?:\s+AS\s+(\S+))?\s*$/i;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines
+    if (!trimmed) continue;
+
+    // Skip comment lines (including parser directives like # syntax=...)
+    if (trimmed.startsWith('#')) continue;
+
+    const match = trimmed.match(fromRegex);
+    if (match) {
+      results.push({
+        image: match[1],
+        alias: match[2] || null,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Extract all EXPOSE instructions from Dockerfile content.
+ * Handles multiple ports per line and optional protocol suffixes.
+ * Non-numeric port values are skipped.
+ *
+ * @param {string} content - Raw Dockerfile content
+ * @returns {Array<ExposedPort>}
+ */
+export function extractExposeInstructions(content) {
+  if (!content || typeof content !== 'string') {
+    return [];
+  }
+
+  const results = [];
+  const lines = content.split('\n');
+
+  // Regex to match EXPOSE line (case-insensitive)
+  const exposeLineRegex = /^\s*EXPOSE\s+(.+)$/i;
+  // Regex to parse individual port entries like "8080", "3000/tcp", "5000/udp"
+  const portEntryRegex = /^(\d+)(?:\/(tcp|udp))?$/i;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines
+    if (!trimmed) continue;
+
+    // Skip comment lines
+    if (trimmed.startsWith('#')) continue;
+
+    const lineMatch = trimmed.match(exposeLineRegex);
+    if (lineMatch) {
+      const portsStr = lineMatch[1].trim();
+      const entries = portsStr.split(/\s+/);
+
+      for (const entry of entries) {
+        const portMatch = entry.match(portEntryRegex);
+        if (portMatch) {
+          const port = parseInt(portMatch[1], 10);
+          const protocol = portMatch[2] ? portMatch[2].toLowerCase() : 'tcp';
+          results.push({ port, protocol });
+        }
+        // Non-numeric or invalid entries are silently skipped
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/utils/dockerfileParser.property.test.js
+++ b/src/utils/dockerfileParser.property.test.js
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { parseDockerfile, extractExposeInstructions } from './dockerfileParser';
+
+/**
+ * Property-based tests for the Dockerfile parser.
+ * Uses fast-check to verify correctness properties across many random inputs.
+ *
+ * Validates: Requirements 2.1, 2.2, 2.3, 2.6, 3.1, 3.2, 3.3, 3.4, 7.2
+ */
+describe('Dockerfile Parser - Property-Based Tests', () => {
+  // --- Generators ---
+
+  /** Generate a valid Docker image name from known-good values */
+  const arbImageName = () =>
+    fc.tuple(
+      fc.constantFrom('node', 'python', 'golang', 'nginx', 'redis', 'postgres', 'alpine', 'ubuntu', 'ruby', 'php', 'rust', 'java'),
+      fc.option(
+        fc.constantFrom('latest', '18', '3.11', 'alpine', '18-alpine', '3.11-slim', '16-bullseye', '8.2', '1.21'),
+        { nil: undefined }
+      )
+    ).map(([name, tag]) => tag ? `${name}:${tag}` : name);
+
+  /** Generate a valid alias name from known-good values */
+  const arbAlias = () =>
+    fc.constantFrom('builder', 'runner', 'dev', 'prod', 'base', 'deps', 'test', 'stage', 'final', 'app');
+
+  /** Generate a FROM instruction line */
+  const arbFromLine = (withAlias = false) =>
+    fc.tuple(arbImageName(), withAlias ? arbAlias() : fc.constant(null))
+      .map(([image, alias]) => alias ? `FROM ${image} AS ${alias}` : `FROM ${image}`);
+
+  /** Generate a valid port number (1-65535) */
+  const arbPort = () => fc.integer({ min: 1, max: 65535 });
+
+  /** Generate a protocol */
+  const arbProtocol = () => fc.constantFrom('tcp', 'udp');
+
+  /**
+   * Property 2: FROM Instruction Resolution
+   *
+   * For any valid Dockerfile content with FROM instructions and any target value,
+   * parseDockerfile returns the correct image based on target matching or final FROM fallback.
+   *
+   * Validates: Requirements 2.1, 2.2, 2.3, 2.6
+   */
+  describe('Property 2: FROM Instruction Resolution', () => {
+    it('when target matches an alias, that stage\'s image is returned', () => {
+      fc.assert(
+        fc.property(
+          // Generate 2-5 FROM stages with unique aliases
+          fc.integer({ min: 2, max: 5 }).chain(numStages =>
+            fc.tuple(
+              fc.array(
+                arbImageName(),
+                { minLength: numStages, maxLength: numStages }
+              ),
+              fc.integer({ min: 0, max: numStages - 1 })
+            )
+          ),
+          ([images, targetIdx]) => {
+            // Create unique aliases by using stage_N pattern
+            const stages = images.map((image, i) => [image, `stage${i}`]);
+
+            const content = stages
+              .map(([image, alias]) => `FROM ${image} AS ${alias}`)
+              .join('\n');
+
+            const target = stages[targetIdx][1];
+            const result = parseDockerfile(content, target);
+
+            expect(result.baseImage).toBe(stages[targetIdx][0]);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('when target is null, the final FROM\'s image is returned', () => {
+      fc.assert(
+        fc.property(
+          fc.array(arbFromLine(false), { minLength: 1, maxLength: 5 }),
+          (fromLines) => {
+            const content = fromLines.join('\n');
+            const result = parseDockerfile(content, null);
+
+            // Extract the last FROM image manually
+            const lastLine = fromLines[fromLines.length - 1];
+            const match = lastLine.match(/^FROM\s+(\S+)/i);
+            const expectedImage = match ? match[1] : null;
+
+            expect(result.baseImage).toBe(expectedImage);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('commented FROM lines are never selected', () => {
+      fc.assert(
+        fc.property(
+          fc.tuple(
+            arbImageName(),
+            arbImageName()
+          ),
+          ([commentedImage, realImage]) => {
+            const content = [
+              `# FROM ${commentedImage} AS target`,
+              `FROM ${realImage}`,
+            ].join('\n');
+
+            const result = parseDockerfile(content, null);
+            expect(result.baseImage).toBe(realImage);
+
+            // Even if target matches the commented alias, it should not be selected
+            const resultWithTarget = parseDockerfile(content, 'target');
+            // Since 'target' alias is in a comment, it won't match; falls back to last FROM
+            expect(resultWithTarget.baseImage).toBe(realImage);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 3: EXPOSE Instruction Extraction
+   *
+   * For any Dockerfile with EXPOSE instructions, extractExposeInstructions returns
+   * all ports with correct protocol (default tcp). Non-numeric port values are skipped.
+   *
+   * Validates: Requirements 3.1, 3.2, 3.3, 3.4
+   */
+  describe('Property 3: EXPOSE Instruction Extraction', () => {
+    it('all ports are extracted with correct protocol', () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.array(
+              fc.tuple(arbPort(), fc.option(arbProtocol(), { nil: undefined })),
+              { minLength: 1, maxLength: 5 }
+            ),
+            { minLength: 1, maxLength: 5 }
+          ),
+          (exposeLines) => {
+            // Build Dockerfile content
+            const content = exposeLines.map(ports => {
+              const portStrs = ports.map(([port, proto]) =>
+                proto ? `${port}/${proto}` : `${port}`
+              );
+              return `EXPOSE ${portStrs.join(' ')}`;
+            }).join('\n');
+
+            const result = extractExposeInstructions(content);
+
+            // Flatten expected ports
+            const expected = exposeLines.flatMap(ports =>
+              ports.map(([port, proto]) => ({
+                port,
+                protocol: proto || 'tcp',
+              }))
+            );
+
+            expect(result).toEqual(expected);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('non-numeric port values are skipped', () => {
+      fc.assert(
+        fc.property(
+          fc.tuple(
+            fc.array(arbPort(), { minLength: 1, maxLength: 3 }),
+            fc.array(
+              fc.stringMatching(/^[a-z${}_.][a-z${}_.]{0,7}$/),
+              { minLength: 1, maxLength: 3 }
+            )
+          ),
+          ([validPorts, invalidPorts]) => {
+            // Mix valid and invalid ports in an EXPOSE line
+            const allEntries = [
+              ...validPorts.map(p => `${p}`),
+              ...invalidPorts,
+            ];
+            const content = `EXPOSE ${allEntries.join(' ')}`;
+
+            const result = extractExposeInstructions(content);
+
+            // Only valid numeric ports should be extracted
+            expect(result.length).toBe(validPorts.length);
+            for (let i = 0; i < validPorts.length; i++) {
+              expect(result[i].port).toBe(validPorts[i]);
+              expect(result[i].protocol).toBe('tcp');
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * Property 9: Parser Robustness
+   *
+   * For any arbitrary string input (including empty, binary-like, random unicode),
+   * parseDockerfile never throws an exception.
+   *
+   * Validates: Requirements 7.2
+   */
+  describe('Property 9: Parser Robustness', () => {
+    it('parseDockerfile never throws for any arbitrary string', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 0, maxLength: 1000 }),
+          (input) => {
+            const result = parseDockerfile(input);
+            expect(result).toBeDefined();
+            expect(result).toHaveProperty('baseImage');
+            expect(result).toHaveProperty('exposedPorts');
+            expect(Array.isArray(result.exposedPorts)).toBe(true);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('parseDockerfile never throws for strings with special characters', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 0, maxLength: 500, unit: 'grapheme-composite' }),
+          (input) => {
+            const result = parseDockerfile(input);
+            expect(result).toBeDefined();
+            expect(result).toHaveProperty('baseImage');
+            expect(result).toHaveProperty('exposedPorts');
+            expect(Array.isArray(result.exposedPorts)).toBe(true);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('parseDockerfile never throws for non-string inputs', () => {
+      const nonStringInputs = [null, undefined, 0, 123, true, false, {}, [], NaN];
+      for (const input of nonStringInputs) {
+        const result = parseDockerfile(input);
+        expect(result).toEqual({ baseImage: null, exposedPorts: [] });
+      }
+    });
+  });
+});

--- a/src/utils/dockerfileParser.test.js
+++ b/src/utils/dockerfileParser.test.js
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { parseDockerfile, extractFromInstructions, extractExposeInstructions } from './dockerfileParser';
+
+describe('dockerfileParser', () => {
+  describe('parseDockerfile', () => {
+    it('parses single FROM with tag', () => {
+      const content = 'FROM node:18-alpine\n';
+      const result = parseDockerfile(content);
+      expect(result.baseImage).toBe('node:18-alpine');
+      expect(result.exposedPorts).toEqual([]);
+    });
+
+    it('parses FROM with no tag', () => {
+      const content = 'FROM ubuntu\n';
+      const result = parseDockerfile(content);
+      expect(result.baseImage).toBe('ubuntu');
+    });
+
+    it('returns last FROM in multi-stage when no target specified', () => {
+      const content = [
+        'FROM node:18 AS builder',
+        'RUN npm install',
+        'FROM nginx:alpine AS runner',
+        'COPY --from=builder /app /usr/share/nginx/html',
+      ].join('\n');
+
+      const result = parseDockerfile(content);
+      expect(result.baseImage).toBe('nginx:alpine');
+    });
+
+    it('returns matching FROM when target is specified', () => {
+      const content = [
+        'FROM node:18 AS builder',
+        'RUN npm install',
+        'FROM nginx:alpine AS runner',
+        'COPY --from=builder /app /usr/share/nginx/html',
+      ].join('\n');
+
+      const result = parseDockerfile(content, 'builder');
+      expect(result.baseImage).toBe('node:18');
+    });
+
+    it('falls back to last FROM when target does not match any alias', () => {
+      const content = [
+        'FROM node:18 AS builder',
+        'FROM nginx:alpine AS runner',
+      ].join('\n');
+
+      const result = parseDockerfile(content, 'nonexistent');
+      expect(result.baseImage).toBe('nginx:alpine');
+    });
+
+    it('handles FROM with build arg variable', () => {
+      const content = 'FROM ${BASE_IMAGE}\n';
+      const result = parseDockerfile(content);
+      expect(result.baseImage).toBe('${BASE_IMAGE}');
+    });
+
+    it('returns safe defaults for empty content', () => {
+      const result = parseDockerfile('');
+      expect(result.baseImage).toBeNull();
+      expect(result.exposedPorts).toEqual([]);
+    });
+
+    it('returns safe defaults for null content', () => {
+      const result = parseDockerfile(null);
+      expect(result.baseImage).toBeNull();
+      expect(result.exposedPorts).toEqual([]);
+    });
+
+    it('returns safe defaults for undefined content', () => {
+      const result = parseDockerfile(undefined);
+      expect(result.baseImage).toBeNull();
+      expect(result.exposedPorts).toEqual([]);
+    });
+
+    it('ignores comment lines', () => {
+      const content = [
+        '# FROM fake:image',
+        'FROM real:image',
+      ].join('\n');
+
+      const result = parseDockerfile(content);
+      expect(result.baseImage).toBe('real:image');
+    });
+
+    it('ignores parser directives', () => {
+      const content = [
+        '# syntax=docker/dockerfile:1',
+        'FROM node:18',
+      ].join('\n');
+
+      const result = parseDockerfile(content);
+      expect(result.baseImage).toBe('node:18');
+    });
+
+    it('handles target matching case-insensitively', () => {
+      const content = [
+        'FROM node:18 AS Builder',
+        'FROM nginx:alpine AS Runner',
+      ].join('\n');
+
+      const result = parseDockerfile(content, 'builder');
+      expect(result.baseImage).toBe('node:18');
+    });
+  });
+
+  describe('extractFromInstructions', () => {
+    it('extracts single FROM instruction', () => {
+      const content = 'FROM node:18-alpine\n';
+      const result = extractFromInstructions(content);
+      expect(result).toEqual([{ image: 'node:18-alpine', alias: null }]);
+    });
+
+    it('extracts FROM with AS alias', () => {
+      const content = 'FROM node:18 AS builder\n';
+      const result = extractFromInstructions(content);
+      expect(result).toEqual([{ image: 'node:18', alias: 'builder' }]);
+    });
+
+    it('extracts multiple FROM instructions', () => {
+      const content = [
+        'FROM node:18 AS builder',
+        'RUN npm install',
+        'FROM nginx:alpine AS runner',
+      ].join('\n');
+
+      const result = extractFromInstructions(content);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ image: 'node:18', alias: 'builder' });
+      expect(result[1]).toEqual({ image: 'nginx:alpine', alias: 'runner' });
+    });
+
+    it('skips commented FROM lines', () => {
+      const content = [
+        '# FROM commented:image',
+        'FROM real:image',
+      ].join('\n');
+
+      const result = extractFromInstructions(content);
+      expect(result).toHaveLength(1);
+      expect(result[0].image).toBe('real:image');
+    });
+
+    it('returns empty array for empty content', () => {
+      expect(extractFromInstructions('')).toEqual([]);
+      expect(extractFromInstructions(null)).toEqual([]);
+    });
+
+    it('skips malformed FROM lines gracefully', () => {
+      const content = [
+        'FROM node:18',
+        'FROMNOTVALID something',
+        'FROM ',
+        'FROM nginx:alpine',
+      ].join('\n');
+
+      const result = extractFromInstructions(content);
+      // Only valid FROM lines are extracted
+      expect(result).toHaveLength(2);
+      expect(result[0].image).toBe('node:18');
+      expect(result[1].image).toBe('nginx:alpine');
+    });
+  });
+
+  describe('extractExposeInstructions', () => {
+    it('extracts single EXPOSE port', () => {
+      const content = 'EXPOSE 8080\n';
+      const result = extractExposeInstructions(content);
+      expect(result).toEqual([{ port: 8080, protocol: 'tcp' }]);
+    });
+
+    it('extracts multiple ports on one line', () => {
+      const content = 'EXPOSE 8080 3000 9090\n';
+      const result = extractExposeInstructions(content);
+      expect(result).toEqual([
+        { port: 8080, protocol: 'tcp' },
+        { port: 3000, protocol: 'tcp' },
+        { port: 9090, protocol: 'tcp' },
+      ]);
+    });
+
+    it('extracts ports with protocol suffix', () => {
+      const content = 'EXPOSE 8080/tcp 5000/udp\n';
+      const result = extractExposeInstructions(content);
+      expect(result).toEqual([
+        { port: 8080, protocol: 'tcp' },
+        { port: 5000, protocol: 'udp' },
+      ]);
+    });
+
+    it('aggregates ports from multiple EXPOSE lines', () => {
+      const content = [
+        'EXPOSE 8080',
+        'EXPOSE 3000/tcp',
+        'EXPOSE 9090/udp',
+      ].join('\n');
+
+      const result = extractExposeInstructions(content);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ port: 8080, protocol: 'tcp' });
+      expect(result[1]).toEqual({ port: 3000, protocol: 'tcp' });
+      expect(result[2]).toEqual({ port: 9090, protocol: 'udp' });
+    });
+
+    it('skips non-numeric port values', () => {
+      const content = 'EXPOSE 8080 $PORT 3000\n';
+      const result = extractExposeInstructions(content);
+      expect(result).toEqual([
+        { port: 8080, protocol: 'tcp' },
+        { port: 3000, protocol: 'tcp' },
+      ]);
+    });
+
+    it('skips commented EXPOSE lines', () => {
+      const content = [
+        '# EXPOSE 9999',
+        'EXPOSE 8080',
+      ].join('\n');
+
+      const result = extractExposeInstructions(content);
+      expect(result).toHaveLength(1);
+      expect(result[0].port).toBe(8080);
+    });
+
+    it('returns empty array for empty content', () => {
+      expect(extractExposeInstructions('')).toEqual([]);
+      expect(extractExposeInstructions(null)).toEqual([]);
+    });
+
+    it('handles EXPOSE with mixed valid and invalid entries', () => {
+      const content = 'EXPOSE 8080 abc 3000/udp invalid/tcp\n';
+      const result = extractExposeInstructions(content);
+      expect(result).toEqual([
+        { port: 8080, protocol: 'tcp' },
+        { port: 3000, protocol: 'udp' },
+      ]);
+    });
+  });
+});

--- a/src/utils/githubExamples.js
+++ b/src/utils/githubExamples.js
@@ -1,0 +1,260 @@
+/**
+ * GitHub-based example fetcher for docker/awesome-compose.
+ * Fetches example listings and YAML content on-demand from GitHub's raw content CDN.
+ * 
+ * Strategy:
+ * - Directory listing: fetched once from GitHub Contents API, cached in memory
+ * - YAML content: fetched on-demand when user selects an example (raw.githubusercontent.com)
+ * - README descriptions: fetched alongside YAML for richer display
+ * - No bundling of remote content — everything is fetched at runtime
+ * - Graceful fallback if GitHub is unreachable (static examples still work)
+ */
+
+const REPO_OWNER = 'docker';
+const REPO_NAME = 'awesome-compose';
+const BRANCH = 'master';
+
+const CONTENTS_API = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents`;
+const RAW_BASE = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}`;
+
+// Directories to skip (not compose examples)
+const SKIP_DIRS = new Set([
+    '.github', 'official-documentation-samples', 'docs',
+]);
+
+// Files that indicate a directory is a compose example
+const COMPOSE_FILENAMES = ['compose.yaml', 'compose.yml', 'docker-compose.yaml', 'docker-compose.yml'];
+
+// Known name overrides for better display
+const NAME_OVERRIDES = {
+    'angular': 'Angular',
+    'apache-php': 'Apache + PHP',
+    'aspnet-mssql': 'ASP.NET + MSSQL',
+    'django': 'Django',
+    'elasticsearch-logstash-kibana': 'ELK Stack',
+    'fastapi': 'FastAPI',
+    'flask': 'Flask',
+    'flask-redis': 'Flask + Redis',
+    'gitea-postgres': 'Gitea + PostgreSQL',
+    'minecraft': 'Minecraft Server',
+    'nextcloud-postgres': 'Nextcloud + PostgreSQL',
+    'nextcloud-redis-mariadb': 'Nextcloud + Redis + MariaDB',
+    'nginx-aspnet-mysql': 'Nginx + ASP.NET + MySQL',
+    'nginx-flask-mongo': 'Nginx + Flask + MongoDB',
+    'nginx-flask-mysql': 'Nginx + Flask + MySQL',
+    'nginx-golang': 'Nginx + Go',
+    'nginx-golang-mysql': 'Nginx + Go + MySQL',
+    'nginx-golang-postgres': 'Nginx + Go + PostgreSQL',
+    'nginx-nodejs-redis': 'Nginx + Node.js + Redis',
+    'nginx-wsgi-flask': 'Nginx + WSGI + Flask',
+    'pihole-cloudflared-DoH': 'Pi-hole + Cloudflared (DoH)',
+    'plex': 'Plex Media Server',
+    'portainer': 'Portainer',
+    'postgresql-pgadmin': 'PostgreSQL + pgAdmin',
+    'prometheus-grafana': 'Prometheus + Grafana',
+    'react-express-mongodb': 'React + Express + MongoDB',
+    'react-express-mysql': 'React + Express + MySQL',
+    'react-java-mysql': 'React + Java + MySQL',
+    'react-nginx': 'React + Nginx',
+    'react-rust-postgres': 'React + Rust + PostgreSQL',
+    'sparkjava': 'Spark Java',
+    'sparkjava-mysql': 'Spark Java + MySQL',
+    'spring-postgres': 'Spring Boot + PostgreSQL',
+    'traefik-golang': 'Traefik + Go',
+    'vuejs': 'Vue.js',
+    'wasmedge-kafka-mysql': 'WasmEdge + Kafka + MySQL',
+    'wasmedge-mysql-nginx': 'WasmEdge + MySQL + Nginx',
+    'wireguard': 'WireGuard VPN',
+    'wordpress-mysql': 'WordPress + MySQL',
+};
+
+/**
+ * @typedef {Object} RemoteExample
+ * @property {string} id - Directory name (kebab-case)
+ * @property {string} name - Human-readable name
+ * @property {string} source - GitHub URL to the example directory
+ * @property {boolean} isRemote - Always true for remote examples
+ * @property {string|null} yaml - null until fetched
+ * @property {string|null} description - null until fetched from README
+ */
+
+// In-memory caches
+let _directoryCache = null;
+let _directoryCacheTime = 0;
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+// YAML content cache (persists for session)
+const _yamlCache = new Map();
+
+/**
+ * Fetch the list of available examples from awesome-compose repository.
+ * Returns directory names that likely contain compose files.
+ * Results are cached for 5 minutes.
+ * 
+ * @returns {Promise<RemoteExample[]>} Array of remote example entries
+ */
+export async function fetchRemoteExamplesList() {
+    // Return cache if fresh
+    if (_directoryCache && (Date.now() - _directoryCacheTime) < CACHE_TTL) {
+        return _directoryCache;
+    }
+
+    const response = await fetch(CONTENTS_API, {
+        headers: {
+            'Accept': 'application/vnd.github.v3+json',
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+    }
+
+    const contents = await response.json();
+
+    // Filter to directories that are likely compose examples
+    const examples = contents
+        .filter(item => item.type === 'dir' && !SKIP_DIRS.has(item.name) && !item.name.startsWith('.'))
+        .map(item => ({
+            id: item.name,
+            name: NAME_OVERRIDES[item.name] || formatDirName(item.name),
+            source: item.html_url,
+            isRemote: true,
+            yaml: null,
+            description: null,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    // Cache the result
+    _directoryCache = examples;
+    _directoryCacheTime = Date.now();
+
+    return examples;
+}
+
+/**
+ * Fetch the compose YAML content for a specific remote example.
+ * Tries multiple common compose filenames.
+ * Results are cached for the session.
+ * 
+ * @param {string} dirName - The directory name in awesome-compose
+ * @returns {Promise<string>} The raw YAML content
+ * @throws {Error} If no compose file is found
+ */
+export async function fetchRemoteExampleYaml(dirName) {
+    // Check cache first
+    if (_yamlCache.has(dirName)) {
+        return _yamlCache.get(dirName);
+    }
+
+    // Try each possible compose filename
+    for (const filename of COMPOSE_FILENAMES) {
+        const url = `${RAW_BASE}/${dirName}/${filename}`;
+        try {
+            const response = await fetch(url);
+            if (response.ok) {
+                const yaml = await response.text();
+                _yamlCache.set(dirName, yaml);
+                return yaml;
+            }
+        } catch {
+            // Try next filename
+            continue;
+        }
+    }
+
+    throw new Error(`No compose file found in "${dirName}". Tried: ${COMPOSE_FILENAMES.join(', ')}`);
+}
+
+/**
+ * Fetch the README description for a remote example.
+ * Extracts the first meaningful paragraph from the README.
+ * 
+ * @param {string} dirName - The directory name in awesome-compose
+ * @returns {Promise<string|null>} Short description or null
+ */
+export async function fetchRemoteExampleDescription(dirName) {
+    const url = `${RAW_BASE}/${dirName}/README.md`;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) return null;
+
+        const text = await response.text();
+        return extractDescription(text);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Extract a short description from README markdown content.
+ * Looks for the first paragraph after the title.
+ * 
+ * @param {string} markdown - Raw README content
+ * @returns {string|null} First meaningful paragraph or null
+ */
+function extractDescription(markdown) {
+    const lines = markdown.split('\n');
+    let foundTitle = false;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        // Skip empty lines and badges
+        if (!trimmed || trimmed.startsWith('![') || trimmed.startsWith('[![')) continue;
+
+        // Skip title lines
+        if (trimmed.startsWith('#')) {
+            foundTitle = true;
+            continue;
+        }
+
+        // First non-empty, non-title, non-badge line after title
+        if (foundTitle && trimmed.length > 10) {
+            // Clean up markdown formatting
+            return trimmed
+                .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // [text](url) → text
+                .replace(/[*_`]/g, '') // Remove bold/italic/code markers
+                .slice(0, 150); // Cap at 150 chars
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Convert a directory name like "nginx-golang-postgres" to "Nginx Golang Postgres"
+ * Used as fallback when no NAME_OVERRIDE exists.
+ * 
+ * @param {string} dirName
+ * @returns {string}
+ */
+function formatDirName(dirName) {
+    return dirName
+        .split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+        .replace(/\bMysql\b/g, 'MySQL')
+        .replace(/\bMongodb\b/g, 'MongoDB')
+        .replace(/\bPostgresql\b/g, 'PostgreSQL')
+        .replace(/\bPostgres\b/g, 'PostgreSQL')
+        .replace(/\bNodejs\b/g, 'Node.js')
+        .replace(/\bVuejs\b/g, 'Vue.js')
+        .replace(/\bReactjs\b/g, 'React.js')
+        .replace(/\bGolang\b/g, 'Go')
+        .replace(/\bFastapi\b/g, 'FastAPI')
+        .replace(/\bMssql\b/g, 'MSSQL')
+        .replace(/\bAspnet\b/g, 'ASP.NET')
+        .replace(/\bPgadmin\b/g, 'pgAdmin')
+        .replace(/\bDoh\b/g, 'DoH')
+        .replace(/\bWsgi\b/g, 'WSGI')
+        .trim();
+}
+
+/**
+ * Clear all caches (useful for testing or forced refresh)
+ */
+export function clearCache() {
+    _directoryCache = null;
+    _directoryCacheTime = 0;
+    _yamlCache.clear();
+}

--- a/src/utils/githubExamples.test.js
+++ b/src/utils/githubExamples.test.js
@@ -1,0 +1,188 @@
+/* global global */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchRemoteExamplesList, fetchRemoteExampleYaml, fetchRemoteExampleDescription, clearCache } from './githubExamples';
+
+describe('githubExamples', () => {
+    beforeEach(() => {
+        clearCache();
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('fetchRemoteExamplesList', () => {
+        it('fetches and parses directory listing from GitHub API', async () => {
+            const mockResponse = [
+                { name: 'nginx-golang-postgres', type: 'dir', html_url: 'https://github.com/docker/awesome-compose/tree/master/nginx-golang-postgres' },
+                { name: 'react-express-mongodb', type: 'dir', html_url: 'https://github.com/docker/awesome-compose/tree/master/react-express-mongodb' },
+                { name: '.github', type: 'dir', html_url: 'https://github.com/docker/awesome-compose/tree/master/.github' },
+                { name: 'README.md', type: 'file', html_url: 'https://github.com/docker/awesome-compose/blob/master/README.md' },
+            ];
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponse),
+            });
+
+            const result = await fetchRemoteExamplesList();
+
+            expect(result).toHaveLength(2); // Skips .github (hidden) and README.md (file)
+            expect(result[0].id).toBe('nginx-golang-postgres');
+            expect(result[0].name).toBe('Nginx + Go + PostgreSQL'); // From NAME_OVERRIDES
+            expect(result[0].isRemote).toBe(true);
+            expect(result[0].yaml).toBeNull();
+            expect(result[1].id).toBe('react-express-mongodb');
+        });
+
+        it('skips known non-example directories', async () => {
+            const mockResponse = [
+                { name: 'official-documentation-samples', type: 'dir', html_url: 'https://...' },
+                { name: 'nginx-flask-mysql', type: 'dir', html_url: 'https://...' },
+            ];
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponse),
+            });
+
+            const result = await fetchRemoteExamplesList();
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('nginx-flask-mysql');
+        });
+
+        it('caches results for subsequent calls', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve([
+                    { name: 'test-example', type: 'dir', html_url: 'https://...' },
+                ]),
+            });
+
+            await fetchRemoteExamplesList();
+            await fetchRemoteExamplesList();
+
+            expect(global.fetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws on API error', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 403,
+                statusText: 'Forbidden',
+            });
+
+            await expect(fetchRemoteExamplesList()).rejects.toThrow('GitHub API error: 403 Forbidden');
+        });
+    });
+
+    describe('fetchRemoteExampleYaml', () => {
+        it('fetches compose.yaml from raw.githubusercontent.com', async () => {
+            const mockYaml = 'services:\n  web:\n    image: nginx';
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                text: () => Promise.resolve(mockYaml),
+            });
+
+            const result = await fetchRemoteExampleYaml('nginx-example');
+
+            expect(result).toBe(mockYaml);
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('nginx-example/compose.yaml')
+            );
+        });
+
+        it('tries fallback filenames if compose.yaml not found', async () => {
+            const mockYaml = 'services:\n  api:\n    image: node';
+            let callCount = 0;
+
+            global.fetch = vi.fn().mockImplementation((url) => {
+                callCount++;
+                if (url.includes('compose.yaml')) {
+                    return Promise.resolve({ ok: false });
+                }
+                if (url.includes('compose.yml')) {
+                    return Promise.resolve({ ok: true, text: () => Promise.resolve(mockYaml) });
+                }
+                return Promise.resolve({ ok: false });
+            });
+
+            const result = await fetchRemoteExampleYaml('some-example');
+            expect(result).toBe(mockYaml);
+            expect(callCount).toBe(2); // Tried compose.yaml first, then compose.yml
+        });
+
+        it('throws if no compose file found', async () => {
+            global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+            await expect(fetchRemoteExampleYaml('empty-dir')).rejects.toThrow(
+                /No compose file found/
+            );
+        });
+    });
+
+    describe('clearCache', () => {
+        it('forces re-fetch after clearing', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve([
+                    { name: 'example', type: 'dir', html_url: 'https://...' },
+                ]),
+            });
+
+            await fetchRemoteExamplesList();
+            clearCache();
+            await fetchRemoteExamplesList();
+
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('fetchRemoteExampleDescription', () => {
+        it('extracts description from README', async () => {
+            const mockReadme = `# Nginx + Go + PostgreSQL
+
+This is a sample project showing a three-tier web application.
+
+## Getting Started
+...`;
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                text: () => Promise.resolve(mockReadme),
+            });
+
+            const desc = await fetchRemoteExampleDescription('nginx-golang-postgres');
+            expect(desc).toBe('This is a sample project showing a three-tier web application.');
+        });
+
+        it('returns null if README not found', async () => {
+            global.fetch = vi.fn().mockResolvedValue({ ok: false });
+
+            const desc = await fetchRemoteExampleDescription('nonexistent');
+            expect(desc).toBeNull();
+        });
+
+        it('skips badge lines and extracts first paragraph', async () => {
+            const mockReadme = `# Flask
+
+![Build Status](https://img.shields.io/badge/build-passing-green)
+[![Docker](https://img.shields.io/badge/docker-ready-blue)](https://docker.com)
+
+A simple Flask application running in a Docker container.
+
+## Usage
+...`;
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                text: () => Promise.resolve(mockReadme),
+            });
+
+            const desc = await fetchRemoteExampleDescription('flask');
+            expect(desc).toBe('A simple Flask application running in a Docker container.');
+        });
+    });
+});

--- a/src/utils/graphviz.dockerfile.property.test.js
+++ b/src/utils/graphviz.dockerfile.property.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { generateGraphviz } from './graphviz';
+
+/**
+ * Property-based tests for graphviz.js Dockerfile enrichment integration.
+ * Validates: Requirements 5.1, 5.3, 5.4
+ */
+
+// --- Generators ---
+
+/** Generate a valid Docker image name with optional tag */
+const arbImageName = () => fc.oneof(
+    fc.constantFrom('node', 'python', 'golang', 'ruby', 'php', 'java', 'rust'),
+    fc.constantFrom('nginx', 'postgres', 'redis', 'mysql', 'mongo', 'traefik')
+);
+
+const arbImageWithTag = () => fc.tuple(arbImageName(), fc.constantFrom('latest', '18-alpine', '3.11-slim', '16', '8.1'))
+    .map(([name, tag]) => `${name}:${tag}`);
+
+/** Generate a service name (alphanumeric, lowercase) */
+const arbServiceName = () => fc.stringMatching(/^[a-z][a-z0-9_]{1,12}$/).filter(s => s.length >= 2);
+
+describe('Feature: dockerfile-metadata-enrichment, Property 6: Resolved Image Display in DOT Output', () => {
+    it('services with _resolvedImage and no image show image name in DOT output', () => {
+        fc.assert(
+            fc.property(
+                arbServiceName(),
+                arbImageWithTag(),
+                (serviceName, resolvedImage) => {
+                    const state = {
+                        services: {
+                            [serviceName]: {
+                                build: './app',
+                                _resolvedImage: resolvedImage
+                            }
+                        }
+                    };
+
+                    const dot = generateGraphviz(state);
+                    const imageName = resolvedImage.split(':')[0];
+
+                    // The DOT output should contain the image name (without tag)
+                    expect(dot).toContain(imageName);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    /**
+     * Validates: Requirements 5.1, 5.4
+     */
+    it('services with _resolvedImage containing a tag display only the name portion', () => {
+        fc.assert(
+            fc.property(
+                arbServiceName(),
+                arbImageWithTag(),
+                (serviceName, resolvedImage) => {
+                    const state = {
+                        services: {
+                            [serviceName]: {
+                                build: './app',
+                                _resolvedImage: resolvedImage
+                            }
+                        }
+                    };
+
+                    const dot = generateGraphviz(state);
+                    const imageName = resolvedImage.split(':')[0];
+
+                    // Should contain the image name in the label format: <imageName>
+                    expect(dot).toContain(`<${imageName}>`);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});
+
+describe('Feature: dockerfile-metadata-enrichment, Property 7: Tier Classification with Resolved Image', () => {
+    it('services with _resolvedImage containing persistence keywords are placed in persistence tier', () => {
+        const persistenceImages = ['postgres:15', 'mysql:8', 'redis:7-alpine', 'mongo:6', 'mariadb:10'];
+
+        fc.assert(
+            fc.property(
+                arbServiceName(),
+                fc.constantFrom(...persistenceImages),
+                (serviceName, resolvedImage) => {
+                    const state = {
+                        services: {
+                            [serviceName]: {
+                                build: './db',
+                                _resolvedImage: resolvedImage
+                            }
+                        }
+                    };
+
+                    const dot = generateGraphviz(state);
+
+                    // Persistence tier services go into cluster_zone_persistence subgraph
+                    expect(dot).toContain('cluster_zone_persistence');
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    it('services with _resolvedImage containing routing keywords are placed in routing tier', () => {
+        const routingImages = ['nginx:latest', 'traefik:v2.10', 'haproxy:2.8', 'caddy:2', 'envoy:latest'];
+
+        fc.assert(
+            fc.property(
+                arbServiceName(),
+                fc.constantFrom(...routingImages),
+                (serviceName, resolvedImage) => {
+                    const state = {
+                        services: {
+                            [serviceName]: {
+                                build: './proxy',
+                                _resolvedImage: resolvedImage
+                            }
+                        }
+                    };
+
+                    const dot = generateGraphviz(state);
+
+                    // Routing tier services go into cluster_zone_gateway subgraph
+                    expect(dot).toContain('cluster_zone_gateway');
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    it('classifyServiceTier returns same tier for _resolvedImage as it would for explicit image', () => {
+        const tierKeywords = [
+            { image: 'postgres:15', tier: 'persistence' },
+            { image: 'nginx:latest', tier: 'routing' },
+            { image: 'redis:7', tier: 'persistence' },
+            { image: 'traefik:v2', tier: 'routing' },
+            { image: 'node:18', tier: 'application' }
+        ];
+
+        fc.assert(
+            fc.property(
+                arbServiceName(),
+                fc.constantFrom(...tierKeywords),
+                (serviceName, { image, tier }) => {
+                    // Service with explicit image
+                    const stateWithImage = {
+                        services: {
+                            [serviceName]: { image }
+                        }
+                    };
+
+                    // Service with _resolvedImage (no explicit image)
+                    const stateWithResolved = {
+                        services: {
+                            [serviceName]: { build: './app', _resolvedImage: image }
+                        }
+                    };
+
+                    const dotWithImage = generateGraphviz(stateWithImage);
+                    const dotWithResolved = generateGraphviz(stateWithResolved);
+
+                    // Both should produce the same tier subgraph
+                    if (tier === 'persistence') {
+                        expect(dotWithImage).toContain('cluster_zone_persistence');
+                        expect(dotWithResolved).toContain('cluster_zone_persistence');
+                    } else if (tier === 'routing') {
+                        expect(dotWithImage).toContain('cluster_zone_gateway');
+                        expect(dotWithResolved).toContain('cluster_zone_gateway');
+                    }
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -77,7 +77,7 @@ const COLORS = {
  * Classify a service into a tier based on its image/name
  */
 const classifyServiceTier = (name, svc) => {
-    const image = (getValue(svc.image) || '').toLowerCase();
+    const image = (getValue(svc.image) || svc._resolvedImage || '').toLowerCase();
     const serviceName = name.toLowerCase();
 
     // Database/persistence tier
@@ -136,7 +136,22 @@ export const generateGraphviz = (state) => {
     // 2. Collect Ports (Ingress Zone)
     const allPorts = [];
     Object.entries(services).forEach(([name, svc]) => {
-        normalizeArray(getValue(svc.ports)).forEach((portRaw, idx) => {
+        const svcPorts = normalizeArray(getValue(svc.ports));
+
+        // Fallback to _resolvedPorts when no explicit ports
+        if (svcPorts.length === 0 && svc._resolvedPorts && svc._resolvedPorts.length > 0) {
+            svc._resolvedPorts.forEach((rp, idx) => {
+                allPorts.push({
+                    id: `port_${sanitizeId(name)}_${idx}`,
+                    label: String(rp.port),
+                    protocol: rp.protocol || 'tcp',
+                    serviceId: sanitizeId(name)
+                });
+            });
+            return;
+        }
+
+        svcPorts.forEach((portRaw, idx) => {
             const port = getValue(portRaw);
             let hostPort, protocol;
             if (typeof port === 'string') {
@@ -343,8 +358,8 @@ export const generateGraphviz = (state) => {
             const zone = serviceZones.get(name);
             const tier = serviceTiers.get(name);
             const color = COLORS[tier] || COLORS.application;
-            const imageStr = getValue(svc.image);
-            const img = imageStr ? imageStr.split(':')[0] : 'image';
+            const imageStr = getValue(svc.image) || svc._resolvedImage;
+            const img = imageStr ? imageStr.split(':')[0] : 'build';
 
             // Get service-specific icon from centralized utility
             const icon = getServiceEmoji(name, imageStr) + ' ';

--- a/src/utils/graphviz.test.js
+++ b/src/utils/graphviz.test.js
@@ -158,5 +158,80 @@ describe('graphviz utils', () => {
             expect(dot).toContain('nginx');
             expect(dot).toContain('vol_data');
         });
+
+        it('shows _resolvedImage in label when service has no explicit image', () => {
+            const state = {
+                services: {
+                    backend: {
+                        build: './backend',
+                        _resolvedImage: 'node:18-alpine'
+                    }
+                }
+            };
+            const dot = generateGraphviz(state);
+            expect(dot).toContain('<node>');
+            expect(dot).toContain('backend');
+        });
+
+        it('shows "build" when service has neither image nor _resolvedImage', () => {
+            const state = {
+                services: {
+                    myapp: {
+                        build: './app'
+                    }
+                }
+            };
+            const dot = generateGraphviz(state);
+            expect(dot).toContain('<build>');
+        });
+
+        it('shows only image name portion from _resolvedImage (strips tag)', () => {
+            const state = {
+                services: {
+                    api: {
+                        build: './api',
+                        _resolvedImage: 'python:3.11-slim'
+                    }
+                }
+            };
+            const dot = generateGraphviz(state);
+            expect(dot).toContain('<python>');
+            // Should not contain the tag in the label
+            expect(dot).not.toMatch(/<python:3\.11-slim>/);
+        });
+
+        it('uses _resolvedImage for tier classification when image is absent', () => {
+            const state = {
+                services: {
+                    db: {
+                        build: './db',
+                        _resolvedImage: 'postgres:15'
+                    }
+                }
+            };
+            const dot = generateGraphviz(state);
+            // Postgres should be classified as persistence tier
+            expect(dot).toContain('cluster_zone_persistence');
+        });
+
+        it('uses _resolvedPorts as fallback when service has no explicit ports', () => {
+            const state = {
+                services: {
+                    app: {
+                        build: './app',
+                        _resolvedImage: 'node:18',
+                        _resolvedPorts: [
+                            { port: 3000, protocol: 'tcp' },
+                            { port: 8080, protocol: 'tcp' }
+                        ]
+                    }
+                }
+            };
+            const dot = generateGraphviz(state);
+            expect(dot).toContain('label="3000"');
+            expect(dot).toContain('label="8080"');
+            expect(dot).toContain('port_app_0');
+            expect(dot).toContain('port_app_1');
+        });
     });
 });


### PR DESCRIPTION
## Summary

Adds a curated gallery of real-world Docker Compose examples with on-demand GitHub fetching and Dockerfile metadata enrichment.

## What's New

### Examples Gallery
- **Curated tab**: 8 hand-picked examples from awesome-compose (instant, offline)
- **Browse All tab**: Fetches 40+ examples on-demand from GitHub API (zero static bloat)
- Category filtering, search, and responsive modal UI
- "Explore Examples" button added to EmptyState

### Dockerfile Metadata Enrichment
- Fetches Dockerfiles from build context directories (GitHub raw URLs or local fileMap)
- Extracts `FROM` base images (handles multi-stage builds with target matching)
- Extracts `EXPOSE` ports with protocols
- Enriches service nodes in the diagram with resolved image names
- Graceful degradation — enrichment failures never break the diagram

## Testing
- **414 tests passing** across 36 test files
- Unit tests, integration tests, and property-based tests (fast-check)
- 10 correctness properties verified

## No New Dependencies (runtime)
- `fast-check` added as dev dependency only (property-based testing)
- All runtime code uses existing dependencies (js-yaml, lucide-react, etc.)